### PR TITLE
Add geometry module for symbol bounding box calculations

### DIFF
--- a/kicad_sch_api/__init__.py
+++ b/kicad_sch_api/__init__.py
@@ -42,7 +42,7 @@ Advanced Usage:
         print(f"Found {len(issues)} validation issues")
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __author__ = "Circuit-Synth"
 __email__ = "info@circuit-synth.com"
 
@@ -55,7 +55,7 @@ from .library.cache import SymbolLibraryCache, get_symbol_cache
 from .utils.validation import ValidationError, ValidationIssue
 
 # Version info
-VERSION_INFO = (0, 3, 2)
+VERSION_INFO = (0, 3, 3)
 
 # Public API
 __all__ = [

--- a/kicad_sch_api/geometry/__init__.py
+++ b/kicad_sch_api/geometry/__init__.py
@@ -1,0 +1,26 @@
+"""
+Geometry module for KiCad schematic symbol bounding box calculations.
+
+This module provides accurate bounding box calculations for KiCad symbols,
+including font metrics and symbol geometry analysis.
+
+Migrated from circuit-synth to kicad-sch-api for better architectural separation.
+"""
+
+from .font_metrics import (
+    DEFAULT_PIN_LENGTH,
+    DEFAULT_PIN_NAME_OFFSET,
+    DEFAULT_PIN_NUMBER_SIZE,
+    DEFAULT_PIN_TEXT_WIDTH_RATIO,
+    DEFAULT_TEXT_HEIGHT,
+)
+from .symbol_bbox import SymbolBoundingBoxCalculator
+
+__all__ = [
+    "SymbolBoundingBoxCalculator",
+    "DEFAULT_TEXT_HEIGHT",
+    "DEFAULT_PIN_LENGTH",
+    "DEFAULT_PIN_NAME_OFFSET",
+    "DEFAULT_PIN_NUMBER_SIZE",
+    "DEFAULT_PIN_TEXT_WIDTH_RATIO",
+]

--- a/kicad_sch_api/geometry/font_metrics.py
+++ b/kicad_sch_api/geometry/font_metrics.py
@@ -1,0 +1,20 @@
+"""
+Font metrics and text rendering constants for KiCad schematic text.
+
+These constants are used for accurate text bounding box calculations
+and symbol spacing in schematic layouts.
+"""
+
+# KiCad default text size in mm
+# Increased to better match actual KiCad rendering
+DEFAULT_TEXT_HEIGHT = 2.54  # 100 mils (doubled from 50 mils)
+
+# Default pin dimensions
+DEFAULT_PIN_LENGTH = 2.54  # 100 mils
+DEFAULT_PIN_NAME_OFFSET = 0.508  # 20 mils - offset from pin endpoint to label text
+DEFAULT_PIN_NUMBER_SIZE = 1.27  # 50 mils
+
+# Text width ratio for proportional font rendering
+# KiCad uses proportional fonts where average character width is ~0.65x height
+# This prevents label text from extending beyond calculated bounding boxes
+DEFAULT_PIN_TEXT_WIDTH_RATIO = 0.65  # Width to height ratio for pin text (proportional font average)

--- a/kicad_sch_api/geometry/symbol_bbox.py
+++ b/kicad_sch_api/geometry/symbol_bbox.py
@@ -1,0 +1,595 @@
+"""
+symbol_bbox.py
+
+Calculate accurate bounding boxes for KiCad symbols based on their graphical elements.
+This ensures proper spacing and collision detection in schematic layouts.
+
+Migrated from circuit-synth to kicad-sch-api for better architectural separation.
+"""
+
+import logging
+import math
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from .font_metrics import (
+    DEFAULT_PIN_LENGTH,
+    DEFAULT_PIN_NAME_OFFSET,
+    DEFAULT_PIN_NUMBER_SIZE,
+    DEFAULT_PIN_TEXT_WIDTH_RATIO,
+    DEFAULT_TEXT_HEIGHT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SymbolBoundingBoxCalculator:
+    """Calculate the actual bounding box of a symbol from its graphical elements."""
+
+    # Re-export font metrics as class constants for backward compatibility
+    DEFAULT_TEXT_HEIGHT = DEFAULT_TEXT_HEIGHT
+    DEFAULT_PIN_LENGTH = DEFAULT_PIN_LENGTH
+    DEFAULT_PIN_NAME_OFFSET = DEFAULT_PIN_NAME_OFFSET
+    DEFAULT_PIN_NUMBER_SIZE = DEFAULT_PIN_NUMBER_SIZE
+    DEFAULT_PIN_TEXT_WIDTH_RATIO = DEFAULT_PIN_TEXT_WIDTH_RATIO
+
+    @classmethod
+    def calculate_bounding_box(
+        cls,
+        symbol_data: Dict[str, Any],
+        include_properties: bool = True,
+        hierarchical_labels: Optional[List[Dict[str, Any]]] = None,
+        pin_net_map: Optional[Dict[str, str]] = None,
+    ) -> Tuple[float, float, float, float]:
+        """
+        Calculate the actual bounding box of a symbol from its graphical elements.
+
+        Args:
+            symbol_data: Dictionary containing symbol definition from KiCad library
+            include_properties: Whether to include space for Reference/Value labels
+            hierarchical_labels: List of hierarchical labels attached to this symbol
+            pin_net_map: Optional mapping of pin numbers to net names (for accurate label sizing)
+
+        Returns:
+            Tuple of (min_x, min_y, max_x, max_y) in mm
+
+        Raises:
+            ValueError: If symbol data is invalid or bounding box cannot be calculated
+        """
+        if not symbol_data:
+            raise ValueError("Symbol data is None or empty")
+
+        import sys
+        # Reduced logging frequency - only log if DEBUG environment variable is set
+        debug_enabled = os.getenv("CIRCUIT_SYNTH_DEBUG", "").lower() == "true"
+        if debug_enabled:
+            print(f"\n=== CALCULATING BOUNDING BOX ===", file=sys.stderr, flush=True)
+            print(f"include_properties={include_properties}", file=sys.stderr, flush=True)
+
+        min_x = float("inf")
+        min_y = float("inf")
+        max_x = float("-inf")
+        max_y = float("-inf")
+
+        # Process main symbol shapes (handle both 'shapes' and 'graphics' keys)
+        shapes = symbol_data.get("shapes", []) or symbol_data.get("graphics", [])
+        print(f"Processing {len(shapes)} main shapes", file=sys.stderr, flush=True)
+        for shape in shapes:
+            shape_bounds = cls._get_shape_bounds(shape)
+            if shape_bounds:
+                s_min_x, s_min_y, s_max_x, s_max_y = shape_bounds
+                min_x = min(min_x, s_min_x)
+                min_y = min(min_y, s_min_y)
+                max_x = max(max_x, s_max_x)
+                max_y = max(max_y, s_max_y)
+
+        # Process pins (including their labels)
+        pins = symbol_data.get("pins", [])
+        print(f"Processing {len(pins)} main pins", file=sys.stderr, flush=True)
+        for pin in pins:
+            pin_bounds = cls._get_pin_bounds(pin, pin_net_map)
+            if pin_bounds:
+                p_min_x, p_min_y, p_max_x, p_max_y = pin_bounds
+                min_x = min(min_x, p_min_x)
+                min_y = min(min_y, p_min_y)
+                max_x = max(max_x, p_max_x)
+                max_y = max(max_y, p_max_y)
+
+        # Process sub-symbols
+        sub_symbols = symbol_data.get("sub_symbols", [])
+        for sub in sub_symbols:
+            # Sub-symbols can have their own shapes and pins (handle both 'shapes' and 'graphics' keys)
+            sub_shapes = sub.get("shapes", []) or sub.get("graphics", [])
+            for shape in sub_shapes:
+                shape_bounds = cls._get_shape_bounds(shape)
+                if shape_bounds:
+                    s_min_x, s_min_y, s_max_x, s_max_y = shape_bounds
+                    min_x = min(min_x, s_min_x)
+                    min_y = min(min_y, s_min_y)
+                    max_x = max(max_x, s_max_x)
+                    max_y = max(max_y, s_max_y)
+
+            sub_pins = sub.get("pins", [])
+            for pin in sub_pins:
+                pin_bounds = cls._get_pin_bounds(pin, pin_net_map)
+                if pin_bounds:
+                    p_min_x, p_min_y, p_max_x, p_max_y = pin_bounds
+                    min_x = min(min_x, p_min_x)
+                    min_y = min(min_y, p_min_y)
+                    max_x = max(max_x, p_max_x)
+                    max_y = max(max_y, p_max_y)
+
+        # Check if we found any geometry
+        if min_x == float("inf") or max_x == float("-inf"):
+            raise ValueError(f"No valid geometry found in symbol data")
+
+        print(f"After geometry processing: ({min_x:.2f}, {min_y:.2f}) to ({max_x:.2f}, {max_y:.2f})", file=sys.stderr, flush=True)
+        print(f"  Width: {max_x - min_x:.2f}, Height: {max_y - min_y:.2f}", file=sys.stderr, flush=True)
+
+        # Add small margin for text that might extend beyond shapes
+        margin = 0.254  # 10 mils
+        min_x -= margin
+        min_y -= margin
+        max_x += margin
+        max_y += margin
+
+        # Include space for component properties (Reference, Value, Footprint)
+        if include_properties:
+            # Use adaptive spacing based on component dimensions
+            component_width = max_x - min_x
+            component_height = max_y - min_y
+
+            # Adaptive property width: minimum 10mm or 80% of component width
+            property_width = max(10.0, component_width * 0.8)
+            property_height = cls.DEFAULT_TEXT_HEIGHT
+
+            # Adaptive vertical spacing: minimum 5mm or 10% of component height
+            vertical_spacing_above = max(5.0, component_height * 0.1)
+            vertical_spacing_below = max(10.0, component_height * 0.15)
+
+            # Reference label above
+            min_y -= vertical_spacing_above + property_height
+
+            # Value and Footprint labels below
+            max_y += vertical_spacing_below + property_height
+
+            # Extend horizontally for property text
+            center_x = (min_x + max_x) / 2
+            min_x = min(min_x, center_x - property_width / 2)
+            max_x = max(max_x, center_x + property_width / 2)
+
+        logger.debug(
+            f"Calculated bounding box: ({min_x:.2f}, {min_y:.2f}) to ({max_x:.2f}, {max_y:.2f})"
+        )
+
+        print(f"FINAL BBOX: ({min_x:.2f}, {min_y:.2f}) to ({max_x:.2f}, {max_y:.2f})", file=sys.stderr, flush=True)
+        print(f"  Width: {max_x - min_x:.2f}, Height: {max_y - min_y:.2f}", file=sys.stderr, flush=True)
+        print("=" * 50 + "\n", file=sys.stderr, flush=True)
+
+        return (min_x, min_y, max_x, max_y)
+
+    @classmethod
+    def calculate_placement_bounding_box(
+        cls,
+        symbol_data: Dict[str, Any],
+    ) -> Tuple[float, float, float, float]:
+        """
+        Calculate bounding box for PLACEMENT purposes - excludes pin labels.
+
+        This method calculates a tighter bounding box that only includes:
+        - Component body (shapes/graphics)
+        - Pin endpoints (without label text)
+        - Small margin for component properties
+
+        Pin label text is excluded because it extends arbitrarily far based on
+        text length and would cause incorrect spacing in text-flow placement.
+
+        Args:
+            symbol_data: Dictionary containing symbol definition from KiCad library
+
+        Returns:
+            Tuple of (min_x, min_y, max_x, max_y) in mm
+
+        Raises:
+            ValueError: If symbol data is invalid or bounding box cannot be calculated
+        """
+        if not symbol_data:
+            raise ValueError("Symbol data is None or empty")
+
+        import sys
+        print(f"\n=== CALCULATING PLACEMENT BOUNDING BOX (NO PIN LABELS) ===", file=sys.stderr, flush=True)
+
+        min_x = float("inf")
+        min_y = float("inf")
+        max_x = float("-inf")
+        max_y = float("-inf")
+
+        # Process main symbol shapes (handle both 'shapes' and 'graphics' keys)
+        shapes = symbol_data.get("shapes", []) or symbol_data.get("graphics", [])
+        print(f"Processing {len(shapes)} main shapes", file=sys.stderr, flush=True)
+        for shape in shapes:
+            shape_bounds = cls._get_shape_bounds(shape)
+            if shape_bounds:
+                s_min_x, s_min_y, s_max_x, s_max_y = shape_bounds
+                min_x = min(min_x, s_min_x)
+                min_y = min(min_y, s_min_y)
+                max_x = max(max_x, s_max_x)
+                max_y = max(max_y, s_max_y)
+
+        # Process pins WITHOUT labels (just pin endpoints)
+        pins = symbol_data.get("pins", [])
+        print(f"Processing {len(pins)} main pins (NO LABELS)", file=sys.stderr, flush=True)
+        for pin in pins:
+            pin_bounds = cls._get_pin_bounds_no_labels(pin)
+            if pin_bounds:
+                p_min_x, p_min_y, p_max_x, p_max_y = pin_bounds
+                min_x = min(min_x, p_min_x)
+                min_y = min(min_y, p_min_y)
+                max_x = max(max_x, p_max_x)
+                max_y = max(max_y, p_max_y)
+
+        # Process sub-symbols
+        sub_symbols = symbol_data.get("sub_symbols", [])
+        for sub in sub_symbols:
+            # Sub-symbols can have their own shapes and pins
+            sub_shapes = sub.get("shapes", []) or sub.get("graphics", [])
+            for shape in sub_shapes:
+                shape_bounds = cls._get_shape_bounds(shape)
+                if shape_bounds:
+                    s_min_x, s_min_y, s_max_x, s_max_y = shape_bounds
+                    min_x = min(min_x, s_min_x)
+                    min_y = min(min_y, s_min_y)
+                    max_x = max(max_x, s_max_x)
+                    max_y = max(max_y, s_max_y)
+
+            sub_pins = sub.get("pins", [])
+            for pin in sub_pins:
+                pin_bounds = cls._get_pin_bounds_no_labels(pin)
+                if pin_bounds:
+                    p_min_x, p_min_y, p_max_x, p_max_y = pin_bounds
+                    min_x = min(min_x, p_min_x)
+                    min_y = min(min_y, p_min_y)
+                    max_x = max(max_x, p_max_x)
+                    max_y = max(max_y, p_max_y)
+
+        # Check if we found any geometry
+        if min_x == float("inf") or max_x == float("-inf"):
+            raise ValueError(f"No valid geometry found in symbol data")
+
+        print(f"After geometry processing: ({min_x:.2f}, {min_y:.2f}) to ({max_x:.2f}, {max_y:.2f})", file=sys.stderr, flush=True)
+        print(f"  Width: {max_x - min_x:.2f}, Height: {max_y - min_y:.2f}", file=sys.stderr, flush=True)
+
+        # Add small margin for visual spacing
+        margin = 0.635  # 25mil margin (reduced from 50mil)
+        min_x -= margin
+        min_y -= margin
+        max_x += margin
+        max_y += margin
+
+        # Add minimal space for component properties (Reference above, Value below)
+        # Use adaptive spacing based on component height for better visual hierarchy
+        component_height = max_y - min_y
+        property_spacing = max(3.0, component_height * 0.15)  # Adaptive: minimum 3mm or 15% of height
+        property_height = 1.27  # Reduced from 2.54mm
+        min_y -= property_spacing + property_height  # Reference above
+        max_y += property_spacing + property_height  # Value below
+
+        print(f"FINAL PLACEMENT BBOX: ({min_x:.2f}, {min_y:.2f}) to ({max_x:.2f}, {max_y:.2f})", file=sys.stderr, flush=True)
+        print(f"  Width: {max_x - min_x:.2f}, Height: {max_y - min_y:.2f}", file=sys.stderr, flush=True)
+        print("=" * 50 + "\n", file=sys.stderr, flush=True)
+
+        return (min_x, min_y, max_x, max_y)
+
+    @classmethod
+    def calculate_visual_bounding_box(
+        cls, symbol_data: Dict[str, Any], pin_net_map: Optional[Dict[str, str]] = None
+    ) -> Tuple[float, float, float, float]:
+        """
+        Calculate bounding box for visual/debug drawing (includes pin labels, no property spacing).
+
+        This shows the actual component geometry including pin labels.
+        Use this for drawing bounding boxes on schematics.
+
+        Args:
+            symbol_data: Dictionary containing symbol definition
+            pin_net_map: Optional mapping of pin numbers to net names (for accurate label sizing)
+
+        Returns:
+            Tuple of (min_x, min_y, max_x, max_y) in mm
+        """
+        # Initialize bounds
+        min_x = float("inf")
+        min_y = float("inf")
+        max_x = float("-inf")
+        max_y = float("-inf")
+
+        # Process main symbol shapes
+        shapes = symbol_data.get("shapes", []) or symbol_data.get("graphics", [])
+        for shape in shapes:
+            shape_bounds = cls._get_shape_bounds(shape)
+            if shape_bounds:
+                s_min_x, s_min_y, s_max_x, s_max_y = shape_bounds
+                min_x = min(min_x, s_min_x)
+                min_y = min(min_y, s_min_y)
+                max_x = max(max_x, s_max_x)
+                max_y = max(max_y, s_max_y)
+
+        # Process pins WITH labels to get accurate visual bounds
+        pins = symbol_data.get("pins", [])
+        for pin in pins:
+            pin_bounds = cls._get_pin_bounds(pin, pin_net_map)
+            if pin_bounds:
+                p_min_x, p_min_y, p_max_x, p_max_y = pin_bounds
+                min_x = min(min_x, p_min_x)
+                min_y = min(min_y, p_min_y)
+                max_x = max(max_x, p_max_x)
+                max_y = max(max_y, p_max_y)
+
+        # Process sub-symbols
+        sub_symbols = symbol_data.get("sub_symbols", [])
+        for sub in sub_symbols:
+            sub_shapes = sub.get("shapes", []) or sub.get("graphics", [])
+            for shape in sub_shapes:
+                shape_bounds = cls._get_shape_bounds(shape)
+                if shape_bounds:
+                    s_min_x, s_min_y, s_max_x, s_max_y = shape_bounds
+                    min_x = min(min_x, s_min_x)
+                    min_y = min(min_y, s_min_y)
+                    max_x = max(max_x, s_max_x)
+                    max_y = max(max_y, s_max_y)
+
+            sub_pins = sub.get("pins", [])
+            for pin in sub_pins:
+                pin_bounds = cls._get_pin_bounds(pin, pin_net_map)
+                if pin_bounds:
+                    p_min_x, p_min_y, p_max_x, p_max_y = pin_bounds
+                    min_x = min(min_x, p_min_x)
+                    min_y = min(min_y, p_min_y)
+                    max_x = max(max_x, p_max_x)
+                    max_y = max(max_y, p_max_y)
+
+        # Check if we found any geometry
+        if min_x == float("inf") or max_x == float("-inf"):
+            raise ValueError(f"No valid geometry found in symbol data")
+
+        # Add only a tiny margin for visibility (no property spacing)
+        margin = 0.254  # 10mil minimal margin
+        min_x -= margin
+        min_y -= margin
+        max_x += margin
+        max_y += margin
+
+        return (min_x, min_y, max_x, max_y)
+
+    @classmethod
+    def get_symbol_dimensions(
+        cls, symbol_data: Dict[str, Any], include_properties: bool = True, pin_net_map: Optional[Dict[str, str]] = None
+    ) -> Tuple[float, float]:
+        """
+        Get the width and height of a symbol.
+
+        Args:
+            symbol_data: Dictionary containing symbol definition
+            include_properties: Whether to include space for Reference/Value labels
+            pin_net_map: Optional mapping of pin numbers to net names
+
+        Returns:
+            Tuple of (width, height) in mm
+        """
+        min_x, min_y, max_x, max_y = cls.calculate_bounding_box(
+            symbol_data, include_properties, pin_net_map=pin_net_map
+        )
+        width = max_x - min_x
+        height = max_y - min_y
+        return (width, height)
+
+    @classmethod
+    def _get_shape_bounds(
+        cls, shape: Dict[str, Any]
+    ) -> Optional[Tuple[float, float, float, float]]:
+        """Get bounding box for a graphical shape."""
+        shape_type = shape.get("shape_type", "")
+
+        if shape_type == "rectangle":
+            start = shape.get("start", [0, 0])
+            end = shape.get("end", [0, 0])
+            return (
+                min(start[0], end[0]),
+                min(start[1], end[1]),
+                max(start[0], end[0]),
+                max(start[1], end[1]),
+            )
+
+        elif shape_type == "circle":
+            center = shape.get("center", [0, 0])
+            radius = shape.get("radius", 0)
+            return (
+                center[0] - radius,
+                center[1] - radius,
+                center[0] + radius,
+                center[1] + radius,
+            )
+
+        elif shape_type == "arc":
+            # For arcs, we need to consider start, mid, and end points
+            start = shape.get("start", [0, 0])
+            mid = shape.get("mid", [0, 0])
+            end = shape.get("end", [0, 0])
+
+            # Simple approach: use bounding box of all three points
+            # More accurate would be to calculate the actual arc bounds
+            min_x = min(start[0], mid[0], end[0])
+            min_y = min(start[1], mid[1], end[1])
+            max_x = max(start[0], mid[0], end[0])
+            max_y = max(start[1], mid[1], end[1])
+
+            return (min_x, min_y, max_x, max_y)
+
+        elif shape_type == "polyline":
+            points = shape.get("points", [])
+            if not points:
+                return None
+
+            min_x = min(p[0] for p in points)
+            min_y = min(p[1] for p in points)
+            max_x = max(p[0] for p in points)
+            max_y = max(p[1] for p in points)
+
+            return (min_x, min_y, max_x, max_y)
+
+        elif shape_type == "text":
+            # Text bounding box estimation
+            at = shape.get("at", [0, 0])
+            text = shape.get("text", "")
+            # Rough estimation: each character is about 1.27mm wide
+            text_width = len(text) * cls.DEFAULT_TEXT_HEIGHT * 0.6
+            text_height = cls.DEFAULT_TEXT_HEIGHT
+
+            return (
+                at[0] - text_width / 2,
+                at[1] - text_height / 2,
+                at[0] + text_width / 2,
+                at[1] + text_height / 2,
+            )
+
+        return None
+
+    @classmethod
+    def _get_pin_bounds(
+        cls, pin: Dict[str, Any], pin_net_map: Optional[Dict[str, str]] = None
+    ) -> Optional[Tuple[float, float, float, float]]:
+        """Get bounding box for a pin including its labels."""
+        import sys
+
+        # Handle both formats: 'at' array or separate x/y/orientation
+        if "at" in pin:
+            at = pin.get("at", [0, 0])
+            x, y = at[0], at[1]
+            angle = at[2] if len(at) > 2 else 0
+        else:
+            # Handle the format from symbol cache
+            x = pin.get("x", 0)
+            y = pin.get("y", 0)
+            angle = pin.get("orientation", 0)
+
+        length = pin.get("length", cls.DEFAULT_PIN_LENGTH)
+
+        # Calculate pin endpoint based on angle
+        angle_rad = math.radians(angle)
+        end_x = x + length * math.cos(angle_rad)
+        end_y = y + length * math.sin(angle_rad)
+
+        # Start with pin line bounds
+        min_x = min(x, end_x)
+        min_y = min(y, end_y)
+        max_x = max(x, end_x)
+        max_y = max(y, end_y)
+
+        # Add space for pin name and number
+        pin_name = pin.get("name", "")
+        pin_number = pin.get("number", "")
+
+        # Use net name for label sizing if available (hierarchical labels show net names, not pin names)
+        # If no net name match, use minimal fallback to avoid oversized bounding boxes
+        if pin_net_map and pin_number in pin_net_map:
+            label_text = pin_net_map[pin_number]
+            print(f"  PIN {pin_number}: ✅ USING NET '{label_text}' (len={len(label_text)}), at=({x:.2f}, {y:.2f}), angle={angle}", file=sys.stderr, flush=True)
+        else:
+            # No net match - use minimal size (3 chars) instead of potentially long pin name
+            label_text = "XXX"  # 3-character placeholder for unmatched pins
+            print(f"  PIN {pin_number}: ⚠️  NO MATCH, using minimal fallback (pin name was '{pin_name}'), at=({x:.2f}, {y:.2f})", file=sys.stderr, flush=True)
+
+        if label_text and label_text != "~":  # ~ means no name
+            # Calculate text dimensions
+            # For horizontal text: width = char_count * char_width
+            name_width = (
+                len(label_text)
+                * cls.DEFAULT_TEXT_HEIGHT
+                * cls.DEFAULT_PIN_TEXT_WIDTH_RATIO
+            )
+            # For vertical text: height = char_count * char_height (characters stack vertically)
+            name_height = len(label_text) * cls.DEFAULT_TEXT_HEIGHT
+
+            print(f"    label_width={name_width:.2f}, label_height={name_height:.2f} (len={len(label_text)})", file=sys.stderr, flush=True)
+
+            # Adjust bounds based on pin orientation
+            # Labels are placed at PIN ENDPOINT with offset, extending AWAY from the component
+            # Pin angle indicates where the pin points (into component)
+            # Apply KiCad's standard pin name offset (0.508mm / 20 mils)
+            offset = cls.DEFAULT_PIN_NAME_OFFSET
+
+            if angle == 0:  # Pin points right - label extends LEFT from endpoint
+                label_x = end_x - offset - name_width
+                print(f"    Angle 0 (Right pin): min_x {min_x:.2f} -> {label_x:.2f} (offset={offset:.3f})", file=sys.stderr, flush=True)
+                min_x = min(min_x, label_x)
+            elif angle == 180:  # Pin points left - label extends RIGHT from endpoint
+                label_x = end_x + offset + name_width
+                print(f"    Angle 180 (Left pin): max_x {max_x:.2f} -> {label_x:.2f} (offset={offset:.3f})", file=sys.stderr, flush=True)
+                max_x = max(max_x, label_x)
+            elif angle == 90:  # Pin points up - label extends DOWN from endpoint
+                label_y = end_y - offset - name_height
+                print(f"    Angle 90 (Up pin): min_y {min_y:.2f} -> {label_y:.2f} (offset={offset:.3f})", file=sys.stderr, flush=True)
+                min_y = min(min_y, label_y)
+            elif angle == 270:  # Pin points down - label extends UP from endpoint
+                label_y = end_y + offset + name_height
+                print(f"    Angle 270 (Down pin): max_y {max_y:.2f} -> {label_y:.2f} (offset={offset:.3f})", file=sys.stderr, flush=True)
+                max_y = max(max_y, label_y)
+
+        # Pin numbers are typically placed near the component body
+        if pin_number:
+            num_width = (
+                len(pin_number)
+                * cls.DEFAULT_PIN_NUMBER_SIZE
+                * cls.DEFAULT_PIN_TEXT_WIDTH_RATIO
+            )
+            # Add some space for the pin number
+            margin = (
+                cls.DEFAULT_PIN_NUMBER_SIZE * 1.5
+            )  # Increase margin for better spacing
+            min_x -= margin
+            min_y -= margin
+            max_x += margin
+            max_y += margin
+
+        print(f"    Pin bounds: ({min_x:.2f}, {min_y:.2f}) to ({max_x:.2f}, {max_y:.2f})", file=sys.stderr, flush=True)
+        return (min_x, min_y, max_x, max_y)
+
+    @classmethod
+    def _get_pin_bounds_no_labels(
+        cls, pin: Dict[str, Any]
+    ) -> Optional[Tuple[float, float, float, float]]:
+        """Get bounding box for a pin WITHOUT labels - for placement calculations only."""
+        import sys
+
+        # Handle both formats: 'at' array or separate x/y/orientation
+        if "at" in pin:
+            at = pin.get("at", [0, 0])
+            x, y = at[0], at[1]
+            angle = at[2] if len(at) > 2 else 0
+        else:
+            # Handle the format from symbol cache
+            x = pin.get("x", 0)
+            y = pin.get("y", 0)
+            angle = pin.get("orientation", 0)
+
+        length = pin.get("length", cls.DEFAULT_PIN_LENGTH)
+
+        # Calculate pin endpoint based on angle
+        angle_rad = math.radians(angle)
+        end_x = x + length * math.cos(angle_rad)
+        end_y = y + length * math.sin(angle_rad)
+
+        # Only include the pin line itself - NO labels
+        min_x = min(x, end_x)
+        min_y = min(y, end_y)
+        max_x = max(x, end_x)
+        max_y = max(y, end_y)
+
+        # Add small margin for pin graphics (circles, etc)
+        margin = 0.5  # Small margin for pin endpoint graphics
+        min_x -= margin
+        min_y -= margin
+        max_x += margin
+        max_y += margin
+
+        return (min_x, min_y, max_x, max_y)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kicad-sch-api"
-version = "0.3.2"
+version = "0.3.3"
 description = "Professional KiCAD schematic manipulation library with exact format preservation"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,566 @@
+"""
+Test suite for the geometry module (symbol bounding box calculations).
+
+Tests cover:
+- Font metrics constants
+- Symbol bounding box calculation
+- Pin bounds with and without labels
+- Shape bounds for different shape types
+- Placement vs visual bounding boxes
+- Adaptive spacing calculations
+"""
+
+import pytest
+from kicad_sch_api.geometry import (
+    DEFAULT_PIN_LENGTH,
+    DEFAULT_PIN_NAME_OFFSET,
+    DEFAULT_PIN_NUMBER_SIZE,
+    DEFAULT_PIN_TEXT_WIDTH_RATIO,
+    DEFAULT_TEXT_HEIGHT,
+    SymbolBoundingBoxCalculator,
+)
+
+
+class TestFontMetrics:
+    """Test font metrics constants."""
+
+    def test_default_text_height(self):
+        """Test DEFAULT_TEXT_HEIGHT is correct."""
+        assert DEFAULT_TEXT_HEIGHT == 2.54  # 100 mils
+
+    def test_default_pin_length(self):
+        """Test DEFAULT_PIN_LENGTH is correct."""
+        assert DEFAULT_PIN_LENGTH == 2.54  # 100 mils
+
+    def test_default_pin_name_offset(self):
+        """Test DEFAULT_PIN_NAME_OFFSET is correct."""
+        assert DEFAULT_PIN_NAME_OFFSET == 0.508  # 20 mils
+
+    def test_default_pin_number_size(self):
+        """Test DEFAULT_PIN_NUMBER_SIZE is correct."""
+        assert DEFAULT_PIN_NUMBER_SIZE == 1.27  # 50 mils
+
+    def test_default_pin_text_width_ratio(self):
+        """Test DEFAULT_PIN_TEXT_WIDTH_RATIO is correct."""
+        assert DEFAULT_PIN_TEXT_WIDTH_RATIO == 0.65  # Proportional font average
+
+
+class TestSymbolBoundingBoxCalculator:
+    """Test SymbolBoundingBoxCalculator class."""
+
+    def test_class_constants_match_module_constants(self):
+        """Test that class constants match module-level constants."""
+        assert SymbolBoundingBoxCalculator.DEFAULT_TEXT_HEIGHT == DEFAULT_TEXT_HEIGHT
+        assert SymbolBoundingBoxCalculator.DEFAULT_PIN_LENGTH == DEFAULT_PIN_LENGTH
+        assert SymbolBoundingBoxCalculator.DEFAULT_PIN_NAME_OFFSET == DEFAULT_PIN_NAME_OFFSET
+        assert SymbolBoundingBoxCalculator.DEFAULT_PIN_NUMBER_SIZE == DEFAULT_PIN_NUMBER_SIZE
+        assert SymbolBoundingBoxCalculator.DEFAULT_PIN_TEXT_WIDTH_RATIO == DEFAULT_PIN_TEXT_WIDTH_RATIO
+
+    def test_empty_symbol_data_raises_error(self):
+        """Test that empty symbol data raises ValueError."""
+        with pytest.raises(ValueError, match="Symbol data is None or empty"):
+            SymbolBoundingBoxCalculator.calculate_bounding_box(None)
+
+        with pytest.raises(ValueError, match="Symbol data is None or empty"):
+            SymbolBoundingBoxCalculator.calculate_bounding_box({})
+
+    def test_symbol_with_no_geometry_raises_error(self):
+        """Test that symbol with no geometry raises ValueError."""
+        symbol_data = {
+            "shapes": [],
+            "pins": [],
+            "sub_symbols": [],
+        }
+        with pytest.raises(ValueError, match="No valid geometry found"):
+            SymbolBoundingBoxCalculator.calculate_bounding_box(symbol_data)
+
+
+class TestShapeBounds:
+    """Test _get_shape_bounds for different shape types."""
+
+    def test_rectangle_shape_bounds(self):
+        """Test bounding box calculation for rectangle shapes."""
+        shape = {
+            "shape_type": "rectangle",
+            "start": [0, 0],
+            "end": [10, 20],
+        }
+        bounds = SymbolBoundingBoxCalculator._get_shape_bounds(shape)
+        assert bounds == (0, 0, 10, 20)
+
+    def test_rectangle_shape_bounds_reversed(self):
+        """Test rectangle with reversed coordinates."""
+        shape = {
+            "shape_type": "rectangle",
+            "start": [10, 20],
+            "end": [0, 0],
+        }
+        bounds = SymbolBoundingBoxCalculator._get_shape_bounds(shape)
+        assert bounds == (0, 0, 10, 20)
+
+    def test_circle_shape_bounds(self):
+        """Test bounding box calculation for circle shapes."""
+        shape = {
+            "shape_type": "circle",
+            "center": [5, 5],
+            "radius": 3,
+        }
+        bounds = SymbolBoundingBoxCalculator._get_shape_bounds(shape)
+        assert bounds == (2, 2, 8, 8)
+
+    def test_arc_shape_bounds(self):
+        """Test bounding box calculation for arc shapes."""
+        shape = {
+            "shape_type": "arc",
+            "start": [0, 0],
+            "mid": [5, 10],
+            "end": [10, 0],
+        }
+        bounds = SymbolBoundingBoxCalculator._get_shape_bounds(shape)
+        assert bounds == (0, 0, 10, 10)
+
+    def test_polyline_shape_bounds(self):
+        """Test bounding box calculation for polyline shapes."""
+        shape = {
+            "shape_type": "polyline",
+            "points": [[0, 0], [5, 10], [10, 5], [15, 15]],
+        }
+        bounds = SymbolBoundingBoxCalculator._get_shape_bounds(shape)
+        assert bounds == (0, 0, 15, 15)
+
+    def test_polyline_empty_points(self):
+        """Test polyline with no points returns None."""
+        shape = {
+            "shape_type": "polyline",
+            "points": [],
+        }
+        bounds = SymbolBoundingBoxCalculator._get_shape_bounds(shape)
+        assert bounds is None
+
+    def test_text_shape_bounds(self):
+        """Test bounding box calculation for text shapes."""
+        shape = {
+            "shape_type": "text",
+            "at": [10, 10],
+            "text": "TEST",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_shape_bounds(shape)
+        assert bounds is not None
+        # Text bounds should be centered around position
+        min_x, min_y, max_x, max_y = bounds
+        assert min_x < 10 < max_x
+        assert min_y < 10 < max_y
+
+    def test_unknown_shape_type(self):
+        """Test that unknown shape type returns None."""
+        shape = {
+            "shape_type": "unknown_type",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_shape_bounds(shape)
+        assert bounds is None
+
+
+class TestPinBounds:
+    """Test pin bounding box calculations."""
+
+    def test_pin_bounds_basic_horizontal(self):
+        """Test pin bounds with horizontal orientation."""
+        pin = {
+            "at": [0, 0, 0],  # x, y, angle (0 = right)
+            "length": 2.54,
+            "name": "VCC",
+            "number": "1",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin)
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # Pin extends right, label extends left
+        assert min_x < 0
+        assert max_x > 2.54
+
+    def test_pin_bounds_with_net_map(self):
+        """Test pin bounds with net name mapping."""
+        pin = {
+            "at": [0, 0, 0],
+            "length": 2.54,
+            "name": "VCC",
+            "number": "1",
+        }
+        pin_net_map = {"1": "VCC"}
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin, pin_net_map)
+        assert bounds is not None
+
+    def test_pin_bounds_without_net_map_fallback(self):
+        """Test pin bounds without net map uses fallback size."""
+        pin = {
+            "at": [0, 0, 0],
+            "length": 2.54,
+            "name": "VERY_LONG_PIN_NAME",
+            "number": "1",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin, None)
+        assert bounds is not None
+        # Should use 3-character fallback, not full pin name length
+
+    def test_pin_bounds_no_labels(self):
+        """Test pin bounds without labels for placement calculations."""
+        pin = {
+            "at": [0, 0, 0],
+            "length": 2.54,
+            "name": "VCC",
+            "number": "1",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds_no_labels(pin)
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # Bounds should be tighter than with labels
+        width = max_x - min_x
+        height = max_y - min_y
+        assert width < 5  # Small margin only
+        assert height < 5
+
+    def test_pin_bounds_alternative_format(self):
+        """Test pin bounds with alternative x/y/orientation format."""
+        pin = {
+            "x": 0,
+            "y": 0,
+            "orientation": 0,
+            "length": 2.54,
+            "name": "VCC",
+            "number": "1",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin)
+        assert bounds is not None
+
+    def test_pin_bounds_angle_180(self):
+        """Test pin bounds with 180 degree angle (left)."""
+        pin = {
+            "at": [0, 0, 180],
+            "length": 2.54,
+            "name": "GND",
+            "number": "2",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin)
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # Pin extends left, label extends right
+        assert min_x < -2.54
+        assert max_x > 0
+
+    def test_pin_bounds_angle_90(self):
+        """Test pin bounds with 90 degree angle (up)."""
+        pin = {
+            "at": [0, 0, 90],
+            "length": 2.54,
+            "name": "OUT",
+            "number": "3",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin)
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # Pin extends up, label extends down
+        assert min_y < 0
+
+    def test_pin_bounds_angle_270(self):
+        """Test pin bounds with 270 degree angle (down)."""
+        pin = {
+            "at": [0, 0, 270],
+            "length": 2.54,
+            "name": "IN",
+            "number": "4",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin)
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # Pin extends down, label extends up
+        assert max_y > 0
+
+    def test_pin_bounds_no_name(self):
+        """Test pin with no name (tilde)."""
+        pin = {
+            "at": [0, 0, 0],
+            "length": 2.54,
+            "name": "~",
+            "number": "1",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin)
+        assert bounds is not None
+
+
+class TestCompleteSymbolBounds:
+    """Test complete symbol bounding box calculations."""
+
+    def test_simple_symbol_with_shapes_and_pins(self):
+        """Test bounding box for simple symbol with shapes and pins."""
+        symbol_data = {
+            "shapes": [
+                {
+                    "shape_type": "rectangle",
+                    "start": [-5, -5],
+                    "end": [5, 5],
+                }
+            ],
+            "pins": [
+                {
+                    "at": [-5, 0, 180],
+                    "length": 2.54,
+                    "name": "IN",
+                    "number": "1",
+                },
+                {
+                    "at": [5, 0, 0],
+                    "length": 2.54,
+                    "name": "OUT",
+                    "number": "2",
+                },
+            ],
+            "sub_symbols": [],
+        }
+        bounds = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=False
+        )
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # Should include shape and pins with labels
+        assert min_x < -5
+        assert max_x > 5
+
+    def test_symbol_with_properties(self):
+        """Test bounding box calculation with property spacing."""
+        symbol_data = {
+            "shapes": [
+                {
+                    "shape_type": "rectangle",
+                    "start": [-5, -5],
+                    "end": [5, 5],
+                }
+            ],
+            "pins": [],
+            "sub_symbols": [],
+        }
+        bounds_with_props = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=True
+        )
+        bounds_without_props = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=False
+        )
+
+        # With properties should have larger bounds
+        assert bounds_with_props[1] < bounds_without_props[1]  # min_y lower
+        assert bounds_with_props[3] > bounds_without_props[3]  # max_y higher
+
+    def test_symbol_with_subsymbols(self):
+        """Test symbol with sub-symbols."""
+        symbol_data = {
+            "shapes": [
+                {
+                    "shape_type": "rectangle",
+                    "start": [0, 0],
+                    "end": [10, 10],
+                }
+            ],
+            "pins": [],
+            "sub_symbols": [
+                {
+                    "shapes": [
+                        {
+                            "shape_type": "circle",
+                            "center": [20, 20],
+                            "radius": 5,
+                        }
+                    ],
+                    "pins": [
+                        {
+                            "at": [20, 15, 270],
+                            "length": 2.54,
+                            "name": "SUB",
+                            "number": "1",
+                        }
+                    ],
+                }
+            ],
+        }
+        bounds = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=False
+        )
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # Should include both main and sub-symbol geometry
+        assert min_x <= 0
+        assert max_x >= 25  # Circle extends to 25
+
+    def test_placement_bounding_box_excludes_pin_labels(self):
+        """Test that placement bounding box excludes pin labels."""
+        symbol_data = {
+            "shapes": [
+                {
+                    "shape_type": "rectangle",
+                    "start": [-5, -5],
+                    "end": [5, 5],
+                }
+            ],
+            "pins": [
+                {
+                    "at": [-5, 0, 180],
+                    "length": 2.54,
+                    "name": "VERY_LONG_PIN_NAME",
+                    "number": "1",
+                }
+            ],
+            "sub_symbols": [],
+        }
+        full_bounds = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=False
+        )
+        placement_bounds = SymbolBoundingBoxCalculator.calculate_placement_bounding_box(
+            symbol_data
+        )
+
+        # Placement bounds should be tighter horizontally (no pin labels)
+        # Note: Placement includes property spacing vertically, so height may be larger
+        assert placement_bounds[0] > full_bounds[0]  # min_x higher (no left pin label)
+        # Max_x comparison is not reliable due to margins and property spacing
+
+    def test_visual_bounding_box(self):
+        """Test visual bounding box calculation."""
+        symbol_data = {
+            "shapes": [
+                {
+                    "shape_type": "rectangle",
+                    "start": [-5, -5],
+                    "end": [5, 5],
+                }
+            ],
+            "pins": [
+                {
+                    "at": [5, 0, 0],
+                    "length": 2.54,
+                    "name": "OUT",
+                    "number": "1",
+                }
+            ],
+            "sub_symbols": [],
+        }
+        bounds = SymbolBoundingBoxCalculator.calculate_visual_bounding_box(symbol_data)
+        assert bounds is not None
+        # Visual bounds include pin labels but not property spacing
+
+    def test_get_symbol_dimensions(self):
+        """Test get_symbol_dimensions convenience method."""
+        symbol_data = {
+            "shapes": [
+                {
+                    "shape_type": "rectangle",
+                    "start": [0, 0],
+                    "end": [10, 20],
+                }
+            ],
+            "pins": [],
+            "sub_symbols": [],
+        }
+        width, height = SymbolBoundingBoxCalculator.get_symbol_dimensions(
+            symbol_data, include_properties=False
+        )
+        assert width > 10  # Includes margins
+        assert height > 20  # Includes margins
+
+
+class TestAdaptiveSpacing:
+    """Test adaptive spacing calculations."""
+
+    def test_adaptive_property_spacing_small_component(self):
+        """Test adaptive spacing for small components."""
+        # Small component - should use minimum spacing
+        symbol_data = {
+            "shapes": [
+                {
+                    "shape_type": "rectangle",
+                    "start": [0, 0],
+                    "end": [5, 5],
+                }
+            ],
+            "pins": [],
+            "sub_symbols": [],
+        }
+        bounds = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=True
+        )
+        assert bounds is not None
+
+    def test_adaptive_property_spacing_large_component(self):
+        """Test adaptive spacing for large components."""
+        # Large component - should use proportional spacing
+        symbol_data = {
+            "shapes": [
+                {
+                    "shape_type": "rectangle",
+                    "start": [0, 0],
+                    "end": [50, 50],
+                }
+            ],
+            "pins": [],
+            "sub_symbols": [],
+        }
+        bounds = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=True
+        )
+        assert bounds is not None
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_graphics_key_instead_of_shapes(self):
+        """Test that 'graphics' key works as alias for 'shapes'."""
+        symbol_data = {
+            "graphics": [  # Using 'graphics' instead of 'shapes'
+                {
+                    "shape_type": "rectangle",
+                    "start": [0, 0],
+                    "end": [10, 10],
+                }
+            ],
+            "pins": [],
+            "sub_symbols": [],
+        }
+        bounds = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=False
+        )
+        assert bounds is not None
+
+    def test_pin_with_zero_length(self):
+        """Test pin with zero length."""
+        pin = {
+            "at": [0, 0, 0],
+            "length": 0,
+            "name": "TEST",
+            "number": "1",
+        }
+        bounds = SymbolBoundingBoxCalculator._get_pin_bounds(pin)
+        assert bounds is not None
+
+    def test_symbol_with_multiple_pins_and_shapes(self):
+        """Test complex symbol with multiple elements."""
+        symbol_data = {
+            "shapes": [
+                {"shape_type": "rectangle", "start": [0, 0], "end": [20, 30]},
+                {"shape_type": "circle", "center": [10, 15], "radius": 3},
+            ],
+            "pins": [
+                {"at": [0, 10, 180], "length": 2.54, "name": "IN1", "number": "1"},
+                {"at": [0, 20, 180], "length": 2.54, "name": "IN2", "number": "2"},
+                {"at": [20, 10, 0], "length": 2.54, "name": "OUT1", "number": "3"},
+                {"at": [20, 20, 0], "length": 2.54, "name": "OUT2", "number": "4"},
+            ],
+            "sub_symbols": [],
+        }
+        bounds = SymbolBoundingBoxCalculator.calculate_bounding_box(
+            symbol_data, include_properties=True
+        )
+        assert bounds is not None
+        min_x, min_y, max_x, max_y = bounds
+        # Should encompass all elements
+        assert min_x < 0
+        assert max_x > 20
+        assert min_y < 0
+        assert max_y > 30


### PR DESCRIPTION
## Summary

Migrated `SymbolBoundingBoxCalculator` from circuit-synth to kicad-sch-api for better architectural separation. This resolves circuit-synth issue #6 by moving geometry calculation logic to where it properly belongs.

## Changes

### New Geometry Package (`kicad_sch_api/geometry/`)

- **`font_metrics.py`**: KiCad font metrics and text rendering constants
  - `DEFAULT_TEXT_HEIGHT = 2.54mm` (100 mils)
  - `DEFAULT_PIN_LENGTH = 2.54mm`
  - `DEFAULT_PIN_NAME_OFFSET = 0.508mm` (20 mils) 
  - `DEFAULT_PIN_TEXT_WIDTH_RATIO = 0.65` (proportional font average)

- **`symbol_bbox.py`**: Complete `SymbolBoundingBoxCalculator` implementation
  - `calculate_bounding_box()`: Full bounding box with property spacing
  - `calculate_placement_bounding_box()`: Tight bbox for layout (excludes pin labels)
  - `calculate_visual_bounding_box()`: Visual bbox for debug drawing
  - `get_symbol_dimensions()`: Convenience method for width/height
  - Adaptive property spacing based on component dimensions
  - Support for shapes, pins, and sub-symbols
  - Pin label sizing with net name mapping
  - All recent placement fixes preserved (0.65 text ratio, 0.508mm pin offset)

- **`__init__.py`**: Clean exports for public API

### Comprehensive Testing (`tests/test_geometry.py`)

- **36 tests** covering all functionality:
  - Font metrics constants validation
  - Shape bounds for all types (rectangle, circle, arc, polyline, text)
  - Pin bounds with multiple orientations (0°, 90°, 180°, 270°)
  - Pin bounds with and without labels
  - Complete symbol bounding box calculations
  - Placement vs visual bounding box behavior
  - Adaptive spacing for various component sizes
  - Edge cases and error conditions
  - Alternative data formats (graphics vs shapes, x/y vs at)

### Version Bump

- `pyproject.toml`: 0.3.2 → 0.3.3
- `kicad_sch_api/__init__.py`: Updated version info

## Testing

```bash
cd submodules/kicad-sch-api
uv run pytest tests/test_geometry.py -v
```

**Result**: ✅ All 36 tests pass

## Architectural Benefits

1. **Proper Separation**: Geometry logic now lives in kicad-sch-api, not circuit-synth
2. **Standalone Usage**: Other projects can use accurate KiCad geometry calculations
3. **Better Maintainability**: Font metrics and bbox logic in one place
4. **Circuit-synth Integration**: Will update circuit-synth to import from kicad-sch-api

## Migration Notes

This preserves all recent fixes:
- ✅ 0.65 text width ratio (from #158, #159)
- ✅ 0.508mm pin name offset (20 mils)
- ✅ Adaptive designator spacing
- ✅ Placement bbox excludes pin labels
- ✅ Visual bbox includes pin labels

## Next Steps

After merging:
1. Update circuit-synth to import from `kicad_sch_api.geometry`
2. Remove duplicate code from circuit-synth
3. Test circuit-synth integration

## Closes

- circuit-synth#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)