### PR TITLE
fix: Correct LabelType default value from 'local' to 'label'

### DIFF
--- a/kicad_sch_api/core/factories/element_factory.py
+++ b/kicad_sch_api/core/factories/element_factory.py
@@ -126,7 +126,7 @@ class ElementFactory:
             uuid=label_dict.get("uuid", str(uuid.uuid4())),
             position=pos,
             text=label_dict.get("text", ""),
-            label_type=LabelType(label_dict.get("label_type", "local")),
+            label_type=LabelType(label_dict.get("label_type", "label")),
             rotation=label_dict.get("rotation", 0.0),
             size=label_dict.get("size", 1.27),
             shape=(


### PR DESCRIPTION
## Problem

The `LabelType` enum defines `LOCAL` with the value `'label'` (matching KiCad's element type name), not `'local'`. However, `element_factory.py` was using `'local'` as the default value when creating labels from dictionaries.

This caused a `ValueError: 'local' is not a valid LabelType` when loading schematics that contain labels without an explicit `label_type` field.

## Root Cause

```python
# Current (incorrect):
label_type=LabelType(label_dict.get("label_type", "local"))  # ❌

# Fixed:
label_type=LabelType(label_dict.get("label_type", "label"))  # ✅
```

The LabelType enum values are:
- `LabelType.LOCAL = 'label'` (not 'local')
- `LabelType.GLOBAL = 'global_label'`
- `LabelType.HIERARCHICAL = 'hierarchical_label'`

## Solution

Changed the default value from `"local"` to `"label"` to match the actual enum value.

## Impact

This fixes multiple test failures in circuit-synth including:
- Bidirectional sync tests
- Roundtrip preservation tests
- KiCad-to-Python workflow tests
- Hierarchical synchronizer tests

Verified fix resolves 12+ failing tests in circuit-synth test suite.

## Testing

- ✅ All existing kicad-sch-api tests pass
- ✅ circuit-synth integration tests now pass
- ✅ No breaking changes to API