### PR TITLE
fix: Correct Symbol comparison bug in boolean property parsing

### DIFF
--- a/kicad_sch_api/core/parsing_utils.py
+++ b/kicad_sch_api/core/parsing_utils.py
@@ -1,0 +1,63 @@
+"""
+Utility functions for parsing S-expression data.
+
+This module contains helper functions used by various parsers
+to handle common parsing patterns safely and consistently.
+"""
+
+import logging
+from typing import Any
+
+import sexpdata
+
+logger = logging.getLogger(__name__)
+
+
+def parse_bool_property(value: Any, default: bool = True) -> bool:
+    """
+    Parse a boolean property from S-expression data.
+
+    Handles both sexpdata.Symbol and string types, converting yes/no to bool.
+    This is the canonical way to parse boolean properties from KiCad files.
+
+    Args:
+        value: Value from S-expression (Symbol, str, bool, or None)
+        default: Default value if parsing fails or value is None
+
+    Returns:
+        bool: Parsed boolean value
+
+    Examples:
+        >>> parse_bool_property(sexpdata.Symbol('yes'))
+        True
+        >>> parse_bool_property('no')
+        False
+        >>> parse_bool_property(None, default=False)
+        False
+        >>> parse_bool_property('YES')  # Case insensitive
+        True
+
+    Note:
+        This function was added to fix a critical bug where Symbol('yes') == 'yes'
+        returned False, causing properties like in_bom and on_board to be parsed
+        incorrectly.
+    """
+    # If value is None, use default
+    if value is None:
+        return default
+
+    # Convert Symbol to string
+    if isinstance(value, sexpdata.Symbol):
+        value = str(value)
+
+    # Handle string values (case-insensitive)
+    if isinstance(value, str):
+        return value.lower() == "yes"
+
+    # Handle boolean values directly
+    if isinstance(value, bool):
+        return value
+
+    # Unexpected type - use default
+    logger.warning(f"Unexpected type for boolean property: {type(value)}, using default={default}")
+    return default

--- a/kicad_sch_api/parsers/elements/symbol_parser.py
+++ b/kicad_sch_api/parsers/elements/symbol_parser.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 
 import sexpdata
 
+from ...core.parsing_utils import parse_bool_property
 from ...core.types import Point
 from ..base import BaseElementParser
 
@@ -74,9 +75,15 @@ class SymbolParser(BaseElementParser):
                                 prop_value = str(prop_value).replace('\\"', '"')
                             symbol_data["properties"][prop_name] = prop_value
                 elif element_type == "in_bom":
-                    symbol_data["in_bom"] = sub_item[1] == "yes" if len(sub_item) > 1 else True
+                    symbol_data["in_bom"] = parse_bool_property(
+                        sub_item[1] if len(sub_item) > 1 else None,
+                        default=True
+                    )
                 elif element_type == "on_board":
-                    symbol_data["on_board"] = sub_item[1] == "yes" if len(sub_item) > 1 else True
+                    symbol_data["on_board"] = parse_bool_property(
+                        sub_item[1] if len(sub_item) > 1 else None,
+                        default=True
+                    )
 
             return symbol_data
 

--- a/tests/unit/test_parse_bool_property.py
+++ b/tests/unit/test_parse_bool_property.py
@@ -1,0 +1,108 @@
+"""
+Unit tests for parse_bool_property helper function.
+
+This test suite verifies that boolean properties are parsed correctly
+from S-expression data, handling both Symbol and string types.
+
+Regression test for bug where Symbol('yes') == 'yes' returned False,
+causing in_bom and on_board properties to be parsed incorrectly.
+"""
+
+import pytest
+import sexpdata
+
+from kicad_sch_api.core.parsing_utils import parse_bool_property
+
+
+class TestParseBoolProperty:
+    """Test parse_bool_property function handles all input types correctly."""
+
+    def test_symbol_yes(self):
+        """Test that Symbol('yes') returns True."""
+        result = parse_bool_property(sexpdata.Symbol('yes'))
+        assert result is True
+
+    def test_symbol_no(self):
+        """Test that Symbol('no') returns False."""
+        result = parse_bool_property(sexpdata.Symbol('no'))
+        assert result is False
+
+    def test_string_yes(self):
+        """Test that string 'yes' returns True."""
+        result = parse_bool_property('yes')
+        assert result is True
+
+    def test_string_no(self):
+        """Test that string 'no' returns False."""
+        result = parse_bool_property('no')
+        assert result is False
+
+    def test_case_insensitive_yes(self):
+        """Test that YES, Yes, yes all return True."""
+        assert parse_bool_property('YES') is True
+        assert parse_bool_property('Yes') is True
+        assert parse_bool_property('yes') is True
+
+    def test_case_insensitive_no(self):
+        """Test that NO, No, no all return False."""
+        assert parse_bool_property('NO') is False
+        assert parse_bool_property('No') is False
+        assert parse_bool_property('no') is False
+
+    def test_none_with_default_true(self):
+        """Test that None with default=True returns True."""
+        result = parse_bool_property(None, default=True)
+        assert result is True
+
+    def test_none_with_default_false(self):
+        """Test that None with default=False returns False."""
+        result = parse_bool_property(None, default=False)
+        assert result is False
+
+    def test_bool_true_passthrough(self):
+        """Test that boolean True is returned as-is."""
+        result = parse_bool_property(True)
+        assert result is True
+
+    def test_bool_false_passthrough(self):
+        """Test that boolean False is returned as-is."""
+        result = parse_bool_property(False)
+        assert result is False
+
+    def test_unexpected_type_uses_default(self):
+        """Test that unexpected types fall back to default."""
+        result = parse_bool_property(123, default=False)
+        assert result is False
+
+        result = parse_bool_property([1, 2, 3], default=True)
+        assert result is True
+
+    def test_empty_string_returns_false(self):
+        """Test that empty string returns False (not 'yes')."""
+        result = parse_bool_property('')
+        assert result is False
+
+    def test_symbol_regression_bug(self):
+        """
+        Regression test for critical bug.
+
+        Bug: Symbol('yes') == 'yes' returned False, causing
+        in_bom and on_board to be parsed incorrectly.
+
+        This test verifies the bug is fixed by ensuring
+        parse_bool_property correctly handles Symbol objects.
+        """
+        # This is what sexpdata returns when parsing (in_bom yes)
+        sexp = sexpdata.loads('(in_bom yes)')
+        value = sexp[1]  # Symbol('yes')
+
+        # Before fix: Symbol('yes') == 'yes' returned False ❌
+        # After fix: parse_bool_property handles Symbol correctly ✅
+        result = parse_bool_property(value)
+        assert result is True
+
+        # Same for 'no'
+        sexp_no = sexpdata.loads('(in_bom no)')
+        value_no = sexp_no[1]  # Symbol('no')
+        result_no = parse_bool_property(value_no)
+        assert result_no is False


### PR DESCRIPTION
## Summary

Fixed critical bug where `sexpdata.Symbol` objects were compared directly with strings, causing `(in_bom yes)` and `(on_board yes)` to be parsed as `False` instead of `True`.

## Problem

**Root Cause:**
```python
# In symbol_parser.py line 77-79
symbol_data["in_bom"] = sub_item[1] == "yes"  # Bug!
```

- `sub_item[1]` is `Symbol('yes')`, not string `"yes"`
- `Symbol('yes') == "yes"` returns `False`
- Components get `in_bom=False`, `on_board=False`
- kicad-cli netlist export excludes them

**Impact:**
- Components disappear in bidirectional Python ↔ KiCad workflows
- All roundtrip tests fail
- Affects circuit-synth and any tool using kicad-sch-api

## Solution

Created `parse_bool_property()` helper function:

```python
# New file: kicad_sch_api/core/parsing_utils.py

def parse_bool_property(value, default=True):
    """Convert Symbol('yes')/Symbol('no') to bool correctly."""
    if value is None:
        return default
    if isinstance(value, sexpdata.Symbol):
        value = str(value)  # Convert Symbol to string
    if isinstance(value, str):
        return value.lower() == "yes"
    return default
```

**Benefits:**
- Type-safe: Handles Symbol, str, bool, None
- Defensive: Safe defaults prevent crashes
- Centralized: One place to maintain
- Well-tested: 13 comprehensive unit tests

## Changes

1. **Added** `kicad_sch_api/core/parsing_utils.py`
   - New module for parsing utilities
   - Contains `parse_bool_property()` function
   - Documented with examples

2. **Modified** `symbol_parser.py`
   - Replaced 2 buggy comparisons
   - Now uses `parse_bool_property()`
   - Import from parsing_utils

3. **Added** `tests/unit/test_parse_bool_property.py`
   - 13 comprehensive unit tests
   - Covers all input types
   - Includes regression test for this bug

## Testing

**Unit Tests:** ✅ 13/13 passed
```
tests/unit/test_parse_bool_property.py::TestParseBoolProperty::test_symbol_yes PASSED
tests/unit/test_parse_bool_property.py::TestParseBoolProperty::test_symbol_no PASSED
tests/unit/test_parse_bool_property.py::TestParseBoolProperty::test_symbol_regression_bug PASSED
...
```

**Full Suite:** ✅ 64/65 passed (1 pre-existing failure unrelated)

**Verification:**
```python
# Before fix
sexp = sexpdata.loads('(in_bom yes)')
sexp[1] == "yes"  # False ❌

# After fix
parse_bool_property(sexp[1])  # True ✅
```

## Backward Compatibility

✅ **Fully backward compatible**
- Still handles string inputs
- Same defaults as before
- No breaking changes

## Related Issues

- circuit-synth Issue #382: Property corruption bug
- circuit-synth PR #383: Temporary monkey-patch workaround

## Next Steps

1. Merge this PR
2. Release kicad-sch-api v0.3.1 (patch version)
3. Update circuit-synth to remove monkey-patch
4. Close related issues

---

**Ready for review and merge** 🚀