### PR TITLE
Add BaseManager abstract class pattern

### DIFF
--- a/kicad_sch_api/core/managers/__init__.py
+++ b/kicad_sch_api/core/managers/__init__.py
@@ -5,6 +5,7 @@ This package contains specialized managers for different aspects of schematic
 manipulation, enabling clean separation of concerns and better maintainability.
 """
 
+from .base import BaseManager
 from .file_io import FileIOManager
 from .format_sync import FormatSyncManager
 from .graphics import GraphicsManager
@@ -15,6 +16,7 @@ from .validation import ValidationManager
 from .wire import WireManager
 
 __all__ = [
+    "BaseManager",
     "FileIOManager",
     "FormatSyncManager",
     "GraphicsManager",

--- a/kicad_sch_api/core/managers/base.py
+++ b/kicad_sch_api/core/managers/base.py
@@ -1,0 +1,76 @@
+"""Base manager class for schematic operations.
+
+Provides a consistent interface for all manager classes and enforces
+common patterns for validation and data access.
+"""
+
+from abc import ABC
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from ...utils.validation import ValidationIssue
+
+if TYPE_CHECKING:
+    from ..schematic import Schematic
+
+
+class BaseManager(ABC):
+    """Base class for all schematic managers.
+
+    Managers encapsulate complex operations and keep Schematic focused.
+    This base class provides a consistent interface and common utilities
+    for all managers.
+
+    Attributes:
+        _data: Reference to schematic data (optional, varies by manager)
+        _schematic: Reference to parent Schematic instance (optional)
+    """
+
+    def __init__(self, schematic_data: Optional[Dict[str, Any]] = None, **kwargs):
+        """Initialize manager with schematic data reference.
+
+        Args:
+            schematic_data: Reference to schematic data dictionary (optional)
+            **kwargs: Additional manager-specific parameters
+        """
+        self._data = schematic_data
+        self._schematic: Optional["Schematic"] = None
+
+    def set_schematic(self, schematic: "Schematic") -> None:
+        """Set reference to parent schematic.
+
+        This is called by Schematic after manager initialization to establish
+        bidirectional relationship.
+
+        Args:
+            schematic: The parent Schematic instance
+        """
+        self._schematic = schematic
+
+    @property
+    def schematic(self) -> Optional["Schematic"]:
+        """Get the parent schematic instance.
+
+        Returns:
+            The parent Schematic, or None if not set
+        """
+        return self._schematic
+
+    @property
+    def data(self) -> Optional[Dict[str, Any]]:
+        """Get the schematic data dictionary.
+
+        Returns:
+            The schematic data, or None if not set
+        """
+        return self._data
+
+    def validate(self) -> List[ValidationIssue]:
+        """Validate managed elements.
+
+        This is an optional method that managers can override to provide
+        validation. Default implementation returns empty list (no issues).
+
+        Returns:
+            List of validation issues found
+        """
+        return []

--- a/kicad_sch_api/core/managers/file_io.py
+++ b/kicad_sch_api/core/managers/file_io.py
@@ -14,11 +14,12 @@ from ...utils.validation import ValidationError
 from ..config import config
 from ..formatter import ExactFormatter
 from ..parser import SExpressionParser
+from .base import BaseManager
 
 logger = logging.getLogger(__name__)
 
 
-class FileIOManager:
+class FileIOManager(BaseManager):
     """
     Manages file I/O operations for KiCAD schematics.
 
@@ -31,6 +32,7 @@ class FileIOManager:
 
     def __init__(self):
         """Initialize the FileIOManager."""
+        super().__init__()
         self._parser = SExpressionParser(preserve_format=True)
         self._formatter = ExactFormatter()
 

--- a/kicad_sch_api/core/managers/format_sync.py
+++ b/kicad_sch_api/core/managers/format_sync.py
@@ -11,11 +11,12 @@ from typing import Any, Dict, List, Optional, Set, Union
 
 from ..components import Component
 from ..types import Point, Wire
+from .base import BaseManager
 
 logger = logging.getLogger(__name__)
 
 
-class FormatSyncManager:
+class FormatSyncManager(BaseManager):
     """
     Manages synchronization between object models and S-expression data.
 
@@ -34,7 +35,7 @@ class FormatSyncManager:
         Args:
             schematic_data: Reference to schematic data
         """
-        self._data = schematic_data
+        super().__init__(schematic_data)
         self._dirty_flags: Set[str] = set()
         self._change_log: List[Dict[str, Any]] = []
         self._sync_lock = False

--- a/kicad_sch_api/core/managers/graphics.py
+++ b/kicad_sch_api/core/managers/graphics.py
@@ -11,11 +11,12 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..types import Point
+from .base import BaseManager
 
 logger = logging.getLogger(__name__)
 
 
-class GraphicsManager:
+class GraphicsManager(BaseManager):
     """
     Manages graphic elements and drawing shapes in KiCAD schematics.
 
@@ -34,7 +35,7 @@ class GraphicsManager:
         Args:
             schematic_data: Reference to schematic data
         """
-        self._data = schematic_data
+        super().__init__(schematic_data)
 
     def add_rectangle(
         self,

--- a/kicad_sch_api/core/managers/metadata.py
+++ b/kicad_sch_api/core/managers/metadata.py
@@ -8,10 +8,12 @@ paper size, title block, version information, and instance sections.
 import logging
 from typing import Any, Dict, List, Optional
 
+from .base import BaseManager
+
 logger = logging.getLogger(__name__)
 
 
-class MetadataManager:
+class MetadataManager(BaseManager):
     """
     Manages schematic metadata and configuration settings.
 
@@ -30,7 +32,7 @@ class MetadataManager:
         Args:
             schematic_data: Reference to schematic data dictionary
         """
-        self._data = schematic_data
+        super().__init__(schematic_data)
 
     def set_paper_size(self, paper: str) -> None:
         """

--- a/kicad_sch_api/core/managers/sheet.py
+++ b/kicad_sch_api/core/managers/sheet.py
@@ -11,11 +11,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..types import Point
+from .base import BaseManager
 
 logger = logging.getLogger(__name__)
 
 
-class SheetManager:
+class SheetManager(BaseManager):
     """
     Manages hierarchical sheets and multi-sheet project coordination.
 
@@ -34,7 +35,7 @@ class SheetManager:
         Args:
             schematic_data: Reference to schematic data
         """
-        self._data = schematic_data
+        super().__init__(schematic_data)
 
     def add_sheet(
         self,

--- a/kicad_sch_api/core/managers/text_elements.py
+++ b/kicad_sch_api/core/managers/text_elements.py
@@ -11,11 +11,12 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..types import Point
+from .base import BaseManager
 
 logger = logging.getLogger(__name__)
 
 
-class TextElementManager:
+class TextElementManager(BaseManager):
     """
     Manages text elements and labeling in KiCAD schematics.
 
@@ -34,7 +35,7 @@ class TextElementManager:
         Args:
             schematic_data: Reference to schematic data
         """
-        self._data = schematic_data
+        super().__init__(schematic_data)
 
     def add_label(
         self,

--- a/kicad_sch_api/core/managers/validation.py
+++ b/kicad_sch_api/core/managers/validation.py
@@ -11,11 +11,12 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ...utils.validation import ValidationError, ValidationIssue
 from ..types import Point
+from .base import BaseManager
 
 logger = logging.getLogger(__name__)
 
 
-class ValidationManager:
+class ValidationManager(BaseManager):
     """
     Comprehensive validation manager for schematic integrity.
 
@@ -39,7 +40,7 @@ class ValidationManager:
             component_collection: Component collection for validation
             wire_collection: Wire collection for connectivity analysis
         """
-        self._data = schematic_data
+        super().__init__(schematic_data)
         self._components = component_collection
         self._wires = wire_collection
         self._validation_rules = self._initialize_validation_rules()

--- a/kicad_sch_api/core/managers/wire.py
+++ b/kicad_sch_api/core/managers/wire.py
@@ -12,11 +12,12 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from ...library.cache import get_symbol_cache
 from ..types import Point, Wire, WireType
 from ..wires import WireCollection
+from .base import BaseManager
 
 logger = logging.getLogger(__name__)
 
 
-class WireManager:
+class WireManager(BaseManager):
     """
     Manages wire operations and pin connectivity in KiCAD schematics.
 
@@ -39,7 +40,7 @@ class WireManager:
             wire_collection: Wire collection for management
             component_collection: Component collection for pin lookups
         """
-        self._data = schematic_data
+        super().__init__(schematic_data)
         self._wires = wire_collection
         self._components = component_collection
         self._symbol_cache = get_symbol_cache()

--- a/tests/unit/managers/__init__.py
+++ b/tests/unit/managers/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for manager classes."""

--- a/tests/unit/managers/test_base_manager.py
+++ b/tests/unit/managers/test_base_manager.py
@@ -1,0 +1,141 @@
+"""Unit tests for BaseManager abstract class."""
+
+import pytest
+from kicad_sch_api.core.managers.base import BaseManager
+from kicad_sch_api.utils.validation import ValidationIssue
+
+
+class ConcreteManager(BaseManager):
+    """Concrete implementation of BaseManager for testing."""
+
+    def __init__(self, schematic_data=None, **kwargs):
+        super().__init__(schematic_data, **kwargs)
+        self.custom_attr = kwargs.get('custom_attr', 'default')
+
+
+def test_base_manager_initialization_no_data():
+    """Test BaseManager can be initialized without data."""
+    manager = ConcreteManager()
+
+    assert manager.data is None
+    assert manager.schematic is None
+
+
+def test_base_manager_initialization_with_data():
+    """Test BaseManager can be initialized with schematic data."""
+    test_data = {'version': '20230121', 'uuid': 'test-uuid'}
+    manager = ConcreteManager(test_data)
+
+    assert manager.data == test_data
+    assert manager.schematic is None
+
+
+def test_base_manager_set_schematic():
+    """Test setting schematic reference."""
+    manager = ConcreteManager()
+
+    # Mock schematic object
+    mock_schematic = type('MockSchematic', (), {})()
+
+    manager.set_schematic(mock_schematic)
+
+    assert manager.schematic == mock_schematic
+
+
+def test_base_manager_schematic_property():
+    """Test schematic property getter."""
+    manager = ConcreteManager()
+    mock_schematic = type('MockSchematic', (), {})()
+
+    assert manager.schematic is None
+
+    manager.set_schematic(mock_schematic)
+
+    assert manager.schematic == mock_schematic
+
+
+def test_base_manager_data_property():
+    """Test data property getter."""
+    test_data = {'test': 'value'}
+    manager = ConcreteManager(test_data)
+
+    assert manager.data == test_data
+
+
+def test_base_manager_validate_default():
+    """Test default validate() returns empty list."""
+    manager = ConcreteManager()
+
+    issues = manager.validate()
+
+    assert isinstance(issues, list)
+    assert len(issues) == 0
+
+
+def test_base_manager_with_kwargs():
+    """Test BaseManager passes through additional kwargs."""
+    test_data = {'version': '20230121'}
+    manager = ConcreteManager(test_data, custom_attr='custom_value')
+
+    assert manager.data == test_data
+    assert manager.custom_attr == 'custom_value'
+
+
+def test_base_manager_inheritance():
+    """Test that ConcreteManager properly inherits from BaseManager."""
+    manager = ConcreteManager()
+
+    assert isinstance(manager, BaseManager)
+    assert hasattr(manager, 'data')
+    assert hasattr(manager, 'schematic')
+    assert hasattr(manager, 'set_schematic')
+    assert hasattr(manager, 'validate')
+
+
+def test_base_manager_validate_override():
+    """Test that validate() can be overridden."""
+    from kicad_sch_api.utils.validation import ValidationLevel
+
+    class CustomManager(BaseManager):
+        def validate(self):
+            return [ValidationIssue(
+                category='test',
+                message='Custom validation',
+                level=ValidationLevel.WARNING
+            )]
+
+    manager = CustomManager()
+    issues = manager.validate()
+
+    assert len(issues) == 1
+    assert issues[0].level == ValidationLevel.WARNING
+    assert issues[0].message == 'Custom validation'
+
+
+def test_base_manager_multiple_managers_independent():
+    """Test that multiple manager instances are independent."""
+    data1 = {'uuid': 'uuid-1'}
+    data2 = {'uuid': 'uuid-2'}
+
+    manager1 = ConcreteManager(data1)
+    manager2 = ConcreteManager(data2)
+
+    assert manager1.data == data1
+    assert manager2.data == data2
+    assert manager1.data is not manager2.data
+
+
+def test_base_manager_schematic_independence():
+    """Test that schematic references are independent across managers."""
+    manager1 = ConcreteManager()
+    manager2 = ConcreteManager()
+
+    schematic1 = type('Schematic1', (), {})()
+    schematic2 = type('Schematic2', (), {})()
+
+    manager1.set_schematic(schematic1)
+    manager2.set_schematic(schematic2)
+
+    assert manager1.schematic == schematic1
+    assert manager2.schematic == schematic2
+    assert manager1.schematic is not manager2.schematic


### PR DESCRIPTION
## Summary

Implements a consistent `BaseManager` abstract base class for all manager classes to standardize interfaces and enable future enhancements.

Resolves #71

## Changes

### Core Implementation
- Added `BaseManager` abstract base class in `kicad_sch_api/core/managers/base.py` with:
  - Standard `__init__(schematic_data, **kwargs)` signature
  - Schematic reference management via `set_schematic()`
  - Properties for `schematic` and `data` access
  - Default `validate()` implementation (returns empty list)

### Updated Managers (8 total)
All managers now inherit from `BaseManager`:
- ✅ `FileIOManager` - File I/O operations
- ✅ `FormatSyncManager` - Data synchronization  
- ✅ `GraphicsManager` - Graphics elements
- ✅ `MetadataManager` - Schematic metadata
- ✅ `SheetManager` - Hierarchical sheets
- ✅ `TextElementManager` - Text elements
- ✅ `ValidationManager` - Validation operations
- ✅ `WireManager` - Wire operations

### Export
- Updated `kicad_sch_api/core/managers/__init__.py` to export `BaseManager`

### Test Coverage
Added comprehensive unit tests (11 tests) in `tests/unit/managers/test_base_manager.py`:
- Initialization with/without data ✓
- Schematic reference management ✓
- Data property access ✓
- Default validation behavior ✓
- Inheritance verification ✓
- Validation override capability ✓
- Multi-instance independence ✓

## Testing
- ✅ All 11 new BaseManager tests pass
- ✅ Existing test suite: 446 passed, 8 skipped
- ⚠️ 15 pre-existing test failures (unrelated to changes - exist on main branch)

## Impact
- **Low risk**: Purely structural change, no logic modifications
- **Backward compatible**: All existing functionality preserved  
- **Foundation for future improvements**: Enables consistent patterns across managers

## Estimated Effort
- **Planned**: 4 hours
- **Actual**: ~4 hours

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>