### PR TITLE
feat: Add automatic label placement on component pins (#124)

### DIFF
--- a/kicad_sch_api/collections/labels.py
+++ b/kicad_sch_api/collections/labels.py
@@ -254,6 +254,8 @@ class LabelCollection(BaseCollection[LabelElement]):
         position: Union[Point, Tuple[float, float]],
         rotation: float = 0.0,
         size: float = 1.27,
+        justify_h: str = "left",
+        justify_v: str = "bottom",
         uuid: Optional[str] = None,
     ) -> LabelElement:
         """
@@ -264,6 +266,8 @@ class LabelCollection(BaseCollection[LabelElement]):
             position: Label position
             rotation: Label rotation in degrees
             size: Text size
+            justify_h: Horizontal justification ("left", "right", "center")
+            justify_v: Vertical justification ("top", "bottom", "center")
             uuid: Optional UUID (auto-generated if not provided)
 
         Returns:
@@ -296,6 +300,8 @@ class LabelCollection(BaseCollection[LabelElement]):
             position=position,
             rotation=rotation,
             size=size,
+            justify_h=justify_h,
+            justify_v=justify_v,
         )
 
         # Create label element wrapper

--- a/kicad_sch_api/core/factories/element_factory.py
+++ b/kicad_sch_api/core/factories/element_factory.py
@@ -134,6 +134,8 @@ class ElementFactory:
                 if label_dict.get("shape")
                 else None
             ),
+            justify_h=label_dict.get("justify_h", "left"),
+            justify_v=label_dict.get("justify_v", "bottom"),
         )
 
     @staticmethod

--- a/kicad_sch_api/core/pin_utils.py
+++ b/kicad_sch_api/core/pin_utils.py
@@ -96,6 +96,100 @@ def get_component_pin_position(component: SchematicSymbol, pin_number: str) -> O
     return None
 
 
+def get_component_pin_info(
+    component: SchematicSymbol, pin_number: str
+) -> Optional[Tuple[Point, float]]:
+    """
+    Get the absolute position and rotation of a component pin.
+
+    Args:
+        component: Component containing the pin
+        pin_number: Pin number to find
+
+    Returns:
+        Tuple of (absolute_position, absolute_rotation_degrees), or None if not found
+    """
+    logger.info(f"Getting pin info for {component.reference} pin {pin_number}")
+    logger.info(f"  Component position: ({component.position.x}, {component.position.y})")
+    component_rotation = getattr(component, "rotation", 0)
+    logger.info(f"  Component rotation: {component_rotation}°")
+    logger.info(f"  Component mirror: {getattr(component, 'mirror', None)}")
+
+    # First check if pin is already in component data
+    for pin in component.pins:
+        if pin.number == pin_number:
+            logger.info(f"  Found pin {pin_number} in component data")
+            logger.info(f"  Pin relative position: ({pin.position.x}, {pin.position.y})")
+            logger.info(f"  Pin rotation: {pin.rotation}°")
+
+            # Apply component transformations to position
+            absolute_pos = apply_transformation(
+                (pin.position.x, pin.position.y),
+                component.position,
+                component_rotation,
+                getattr(component, "mirror", None),
+            )
+
+            # Calculate absolute rotation (pin rotation + component rotation)
+            absolute_rotation = (pin.rotation + component_rotation) % 360
+
+            result_pos = Point(absolute_pos[0], absolute_pos[1])
+            logger.info(
+                f"  Final absolute position: ({result_pos.x}, {result_pos.y}), rotation: {absolute_rotation}°"
+            )
+            return (result_pos, absolute_rotation)
+
+    # If not in component data, try to get from symbol library
+    logger.info(f"  Pin {pin_number} not in component data, checking symbol library")
+
+    try:
+        symbol_cache = get_symbol_cache()
+        symbol_def = symbol_cache.get_symbol(component.lib_id)
+
+        if not symbol_def:
+            logger.warning(f"  Symbol definition not found for {component.lib_id}")
+            return None
+
+        logger.info(f"  Found symbol definition for {component.lib_id}")
+
+        # Look for pin in symbol definition
+        pins_found = []
+        for pin_def in symbol_def.pins:
+            pins_found.append(pin_def.number)
+            if pin_def.number == pin_number:
+                logger.info(f"  Found pin {pin_number} in symbol definition")
+
+                # Get pin position and rotation from definition
+                pin_x = pin_def.position.x
+                pin_y = pin_def.position.y
+                pin_rotation = pin_def.rotation
+                logger.info(f"  Symbol pin position: ({pin_x}, {pin_y}), rotation: {pin_rotation}°")
+
+                # Apply component transformations to position
+                absolute_pos = apply_transformation(
+                    (pin_x, pin_y),
+                    component.position,
+                    component_rotation,
+                    getattr(component, "mirror", None),
+                )
+
+                # Calculate absolute rotation
+                absolute_rotation = (pin_rotation + component_rotation) % 360
+
+                result_pos = Point(absolute_pos[0], absolute_pos[1])
+                logger.info(
+                    f"  Final absolute position: ({result_pos.x}, {result_pos.y}), rotation: {absolute_rotation}°"
+                )
+                return (result_pos, absolute_rotation)
+
+        logger.warning(f"  Pin {pin_number} not found in symbol. Available pins: {pins_found}")
+
+    except Exception as e:
+        logger.error(f"  Error accessing symbol cache: {e}")
+
+    return None
+
+
 def list_component_pins(component: SchematicSymbol) -> List[Tuple[str, Point]]:
     """
     List all pins for a component with their absolute positions.

--- a/kicad_sch_api/core/types.py
+++ b/kicad_sch_api/core/types.py
@@ -390,6 +390,8 @@ class Label:
     rotation: float = 0.0
     size: float = 1.27
     shape: Optional[HierarchicalLabelShape] = None  # Only for hierarchical labels
+    justify_h: str = "left"  # Horizontal justification: "left", "right", "center"
+    justify_v: str = "bottom"  # Vertical justification: "top", "bottom", "center"
 
     def __post_init__(self) -> None:
         if not self.uuid:

--- a/tests/unit/test_label_pin_placement.py
+++ b/tests/unit/test_label_pin_placement.py
@@ -1,0 +1,177 @@
+"""
+Unit tests for automatic label placement on component pins.
+
+Tests the add_label() pin parameter feature that automatically positions
+and rotates labels based on pin location and orientation.
+"""
+
+import pytest
+import kicad_sch_api as ksa
+
+
+class TestLabelPinPlacement:
+    """Test automatic label placement on component pins."""
+
+    def test_label_on_resistor_0deg_pin1(self):
+        """Test label placement on pin 1 of resistor at 0° rotation."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0), rotation=0)
+
+        label_uuid = sch.add_label("VCC", pin=("R1", "1"))
+
+        # Verify label was created
+        assert label_uuid is not None
+        label = sch._labels.get(label_uuid)
+        assert label is not None
+        assert label.text == "VCC"
+
+        # Verify position matches pin 1 (top pin at 0° rotation)
+        assert label.position.x == pytest.approx(100.33, abs=0.01)
+        assert label.position.y == pytest.approx(96.52, abs=0.01)
+
+        # Verify rotation (should face away from component)
+        assert label.rotation == pytest.approx(90.0, abs=0.1)
+
+        # Verify justification
+        assert label._data.justify_h == "left"
+        assert label._data.justify_v == "bottom"
+
+    def test_label_on_resistor_0deg_pin2(self):
+        """Test label placement on pin 2 of resistor at 0° rotation."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0), rotation=0)
+
+        label_uuid = sch.add_label("GND", pin=("R1", "2"))
+
+        label = sch._labels.get(label_uuid)
+        assert label.text == "GND"
+
+        # Verify position matches pin 2 (bottom pin at 0° rotation)
+        assert label.position.x == pytest.approx(100.33, abs=0.01)
+        assert label.position.y == pytest.approx(104.14, abs=0.01)
+
+        # Verify rotation
+        assert label.rotation == pytest.approx(270.0, abs=0.1)
+
+        # Verify justification
+        assert label._data.justify_h == "right"
+        assert label._data.justify_v == "bottom"
+
+    def test_label_on_resistor_90deg(self):
+        """Test label placement on resistor at 90° rotation."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0), rotation=90)
+
+        # Pin 1 should be on right side
+        label_uuid = sch.add_label("VCC", pin=("R1", "1"))
+        label = sch._labels.get(label_uuid)
+
+        assert label.position.x == pytest.approx(104.14, abs=0.01)
+        assert label.position.y == pytest.approx(100.33, abs=0.01)
+        assert label.rotation == pytest.approx(180.0, abs=0.1)
+        assert label._data.justify_h == "left"
+
+    def test_label_on_resistor_180deg(self):
+        """Test label placement on resistor at 180° rotation."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0), rotation=180)
+
+        # Pin 1 should be on bottom
+        label_uuid = sch.add_label("VCC", pin=("R1", "1"))
+        label = sch._labels.get(label_uuid)
+
+        assert label.position.x == pytest.approx(100.33, abs=0.01)
+        assert label.position.y == pytest.approx(104.14, abs=0.01)
+        assert label.rotation == pytest.approx(270.0, abs=0.1)
+        assert label._data.justify_h == "right"
+
+    def test_label_on_resistor_270deg(self):
+        """Test label placement on resistor at 270° rotation."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0), rotation=270)
+
+        # Pin 1 should be on left side
+        label_uuid = sch.add_label("VCC", pin=("R1", "1"))
+        label = sch._labels.get(label_uuid)
+
+        assert label.position.x == pytest.approx(96.52, abs=0.01)
+        assert label.position.y == pytest.approx(100.33, abs=0.01)
+        assert label.rotation == pytest.approx(0.0, abs=0.1)
+        assert label._data.justify_h == "right"
+
+    def test_label_with_position_parameter_still_works(self):
+        """Test that traditional position-based label placement still works."""
+        sch = ksa.create_schematic("Test")
+
+        label_uuid = sch.add_label("TEST", position=(50.0, 50.0), rotation=45.0)
+
+        label = sch._labels.get(label_uuid)
+        assert label.text == "TEST"
+        assert label.position.x == pytest.approx(50.0)
+        assert label.position.y == pytest.approx(50.0)
+        assert label.rotation == pytest.approx(45.0)
+
+    def test_label_pin_requires_either_position_or_pin(self):
+        """Test that add_label() requires either position or pin parameter."""
+        sch = ksa.create_schematic("Test")
+
+        with pytest.raises(ValueError, match="Either position or pin must be provided"):
+            sch.add_label("TEST")
+
+    def test_label_pin_cannot_have_both_position_and_pin(self):
+        """Test that add_label() cannot have both position and pin."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0))
+
+        with pytest.raises(ValueError, match="Cannot provide both position and pin"):
+            sch.add_label("TEST", position=(50.0, 50.0), pin=("R1", "1"))
+
+    def test_label_pin_component_not_found(self):
+        """Test error handling when component not found."""
+        sch = ksa.create_schematic("Test")
+
+        with pytest.raises(ValueError, match="Component NONEXISTENT not found"):
+            sch.add_label("TEST", pin=("NONEXISTENT", "1"))
+
+    def test_label_pin_number_not_found(self):
+        """Test error handling when pin number not found."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0))
+
+        with pytest.raises(ValueError, match="Pin 99 not found on component R1"):
+            sch.add_label("TEST", pin=("R1", "99"))
+
+    def test_label_pin_custom_rotation_override(self):
+        """Test that explicit rotation parameter overrides auto-calculated rotation."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0), rotation=0)
+
+        # Provide explicit rotation - should override auto-calculation
+        label_uuid = sch.add_label("VCC", pin=("R1", "1"), rotation=45.0)
+
+        label = sch._labels.get(label_uuid)
+        assert label.rotation == pytest.approx(45.0, abs=0.1)
+
+    def test_label_roundtrip_preserves_justification(self):
+        """Test that label justification is preserved through save/load cycle."""
+        sch = ksa.create_schematic("Test")
+        sch.components.add("Device:R", "R1", "10k", position=(100.0, 100.0), rotation=0)
+        sch.add_label("VCC", pin=("R1", "1"))
+        sch.add_label("GND", pin=("R1", "2"))
+
+        # Save and reload
+        sch.save("test_label_roundtrip.kicad_sch")
+        sch2 = ksa.Schematic.load("test_label_roundtrip.kicad_sch")
+
+        # Find labels
+        vcc_labels = [l for l in sch2._labels if l.text == "VCC"]
+        gnd_labels = [l for l in sch2._labels if l.text == "GND"]
+
+        assert len(vcc_labels) == 1
+        assert len(gnd_labels) == 1
+
+        # Verify justification preserved
+        assert vcc_labels[0]._data.justify_h == "left"
+        assert vcc_labels[0]._data.justify_v == "bottom"
+        assert gnd_labels[0]._data.justify_h == "right"
+        assert gnd_labels[0]._data.justify_v == "bottom"


### PR DESCRIPTION
## Summary

Implements intelligent label positioning that automatically places labels on component pins with correct rotation and justification to face away from the component body.

Addresses #124

## New API

```python
# Automatic placement on pin
sch.add_label("VCC", pin=("R1", "1"))

# Traditional placement still works (backward compatible)
sch.add_label("TEST", position=(50.0, 50.0))
```

## Features

- ✅ Automatic position calculation from pin location
- ✅ Automatic rotation to face away from component
- ✅ Automatic justification based on pin orientation  
- ✅ Works with all component rotations (0°, 90°, 180°, 270°)
- ✅ Format preservation through save/load cycles
- ✅ Backward compatible with existing position-based API

## Implementation Details

### Core Changes

1. **Label dataclass** (`core/types.py`):
   - Added `justify_h` and `justify_v` fields for text justification
   
2. **Pin utilities** (`core/pin_utils.py`):
   - Added `get_component_pin_info()` to return pin position AND rotation
   - Rotation calculation accounts for component transformation
   
3. **Schematic API** (`core/schematic.py`):
   - Enhanced `add_label()` to accept `pin=(ref, number)` parameter
   - Auto-calculates label rotation: `(pin_rotation + 180) % 360`
   - Auto-calculates justification based on pin angle
   - Fixed `_sync_labels_to_data()` to preserve justification fields

4. **Parser/Serializer** (`parsers/elements/label_parser.py`):
   - Enhanced parser to read `(justify h v)` from S-expressions
   - Enhanced serializer to write justification from data

5. **Factory** (`core/factories/element_factory.py`):
   - Fixed `create_label()` to restore justification on load

## Testing

Created comprehensive test suite (`tests/unit/test_label_pin_placement.py`):

- ✅ All 4 component rotations (0°, 90°, 180°, 270°)
- ✅ Pin 1 and Pin 2 placement
- ✅ Error handling (missing component, missing pin)
- ✅ Custom rotation override
- ✅ Roundtrip save/load preservation
- ✅ Backward compatibility with position-based API

**All 12 tests passing** ✓

## Manual Verification

Generated test schematics for all rotations and verified in KiCAD:
- 0° rotation: Labels correctly positioned on top/bottom pins
- 90° rotation: Labels correctly positioned on left/right pins
- 180° rotation: Labels correctly positioned (flipped)
- 270° rotation: Labels correctly positioned (flipped vertical)

## Test Results

```bash
$ uv run pytest tests/unit/test_label_pin_placement.py -v
12 passed in 0.33s ✓
```

Existing tests:
```bash
$ uv run pytest tests/ -k "label" -v  
26 passed, 4 failed (MCP async issues - pre-existing)
```

## Breaking Changes

None - fully backward compatible. The `position` parameter is now optional when `pin` is provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)