### PR TITLE
fix(mcp): Remove non-existent ComponentCollection.all() calls

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -147,7 +147,7 @@ async def load_schematic(file_path: str) -> dict:
         set_current_schematic(schematic)
 
         # Count components
-        component_count = len(list(schematic.components.all()))
+        component_count = len(schematic.components)
 
         logger.info(
             f"[MCP] Loaded schematic: {schematic.title_block.title} "
@@ -263,7 +263,7 @@ async def get_schematic_info() -> dict:
 
     try:
         # Collect schematic information
-        components = list(schematic.components.all())
+        components = list(schematic.components)
         component_refs = [c.reference for c in components]
 
         info = {


### PR DESCRIPTION
## Summary
Fixes MCP server `load_schematic` and `get_schematic_info` tools that were calling a non-existent `ComponentCollection.all()` method.

## Problem
The MCP server was calling `schematic.components.all()` which doesn't exist. `ComponentCollection` supports direct iteration via `__iter__` but has no `.all()` method.

## Changes
- `mcp_server/server.py` line 150: Changed `len(list(schematic.components.all()))` → `len(schematic.components)`
- `mcp_server/server.py` line 266: Changed `list(schematic.components.all())` → `list(schematic.components)`

## Testing
- ✅ Tested `len(schematic.components)` works correctly
- ✅ Tested `list(schematic.components)` works correctly  
- ✅ Tested direct iteration over components
- ✅ Tested empty schematics are handled properly
- ✅ Tested exact MCP load/save/reload scenario

## Related
- Closes #111

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>