### PR TITLE
Fix property visibility preservation (Issue #140)

### DIFF
--- a/kicad_sch_api/collections/components.py
+++ b/kicad_sch_api/collections/components.py
@@ -171,6 +171,11 @@ class Component:
         """Dictionary of all component properties."""
         return self._data.properties
 
+    @property
+    def hidden_properties(self) -> "set[str]":
+        """Set of property names that have (hide yes) flag."""
+        return self._data.hidden_properties
+
     def get_property(self, name: str, default: Optional[str] = None) -> Optional[str]:
         """
         Get property value by name.
@@ -214,9 +219,55 @@ class Component:
         """
         if name in self._data.properties:
             del self._data.properties[name]
+            # Also remove from hidden_properties if present
+            self._data.hidden_properties.discard(name)
             self._collection._mark_modified()
             return True
         return False
+
+    def add_property(self, name: str, value: str, hidden: bool = False) -> None:
+        """
+        Add or update a component property with visibility control.
+
+        Sets the property value and manages its visibility state. If the property
+        already exists, both value and visibility are updated.
+
+        Args:
+            name: Property name (e.g., "MPN", "Manufacturer", "Tolerance")
+            value: Property value
+            hidden: If True, property will have (hide yes) flag in S-expression.
+                   If False, property will be visible on schematic. Default: False
+
+        Example:
+            >>> component.add_property("MPN", "RC0603FR-0710KL", hidden=True)
+            >>> component.add_property("Tolerance", "1%", hidden=False)
+        """
+        self._data.add_property(name, value, hidden)
+        self._collection._mark_modified()
+        logger.debug(f"Added property {self.reference}.{name} = {value} (hidden={hidden})")
+
+    def add_properties(self, props: Dict[str, str], hidden: bool = False) -> None:
+        """
+        Add or update multiple properties with same visibility setting.
+
+        Convenience method for bulk property operations. All properties will
+        have the same visibility state.
+
+        Args:
+            props: Dictionary of property name/value pairs
+            hidden: If True, all properties will be hidden. If False, all will
+                   be visible. Default: False
+
+        Example:
+            >>> component.add_properties({
+            ...     "MPN": "RC0603FR-0710KL",
+            ...     "Manufacturer": "Yageo",
+            ...     "Supplier": "Digikey"
+            ... }, hidden=True)
+        """
+        self._data.add_properties(props, hidden)
+        self._collection._mark_modified()
+        logger.debug(f"Added {len(props)} properties to {self.reference} (hidden={hidden})")
 
     # Text effects (position, font, color, etc.)
     def get_property_effects(self, property_name: str) -> Dict[str, Any]:

--- a/tests/reference_kicad_projects/property_preservation/README.md
+++ b/tests/reference_kicad_projects/property_preservation/README.md
@@ -1,0 +1,81 @@
+# Reference: Property Preservation
+
+## Purpose
+
+This reference schematic demonstrates complete component property preservation including custom properties with mixed visibility states.
+
+## Contents
+
+### Component: R1 (Device:R)
+- **Position:** (100.33, 100.33) with rotation=0
+- **Value:** 10k
+- **Footprint:** Resistor_SMD:R_0603_1608Metric
+
+### Properties
+
+| Property | Value | Visible | Justify | Notes |
+|----------|-------|---------|---------|-------|
+| Reference | "R1" | ✓ Yes | left | Standard property |
+| Value | "10k" | ✓ Yes | left | Standard property |
+| Footprint | "Resistor_SMD:R_0603_1608Metric" | ✗ Hidden | - | Standard property |
+| Datasheet | "~" | ✗ Hidden | - | Standard property |
+| Description | "" | ✓ Yes | - | Standard property (empty value) |
+| MPN | "C0603FR-0710KL" | ✗ Hidden | - | Custom property |
+| Manufacturer | "Yageo" | ✓ Yes | right top | Custom property with justify |
+| Tolearnce | "1%" | ✓ Yes | left bottom | Custom property with justify (typo preserved) |
+
+## Key S-expression Format Discovered
+
+### Visible Property (no hide flag)
+```lisp
+(property "Reference" "R1"
+  (at 102.87 99.0599 0)
+  (effects
+    (font (size 1.27 1.27))
+    (justify left)
+  )
+)
+```
+
+### Hidden Property (with hide flag)
+```lisp
+(property "Footprint" "Resistor_SMD:R_0603_1608Metric"
+  (at 98.552 100.33 90)
+  (effects
+    (font (size 1.27 1.27))
+    (hide yes)
+  )
+)
+```
+
+### Custom Property with Justification
+```lisp
+(property "Manufacturer" "Yageo"
+  (at 100.33 100.33 0)
+  (effects
+    (font (size 1.27 1.27))
+    (justify right top)
+  )
+)
+```
+
+## Critical Format Details
+
+1. **Hide flag format:** `(hide yes)` appears in effects section
+2. **Visible = no hide flag:** Visible properties have NO hide flag (not `(hide no)`, just absent)
+3. **Justification preserved:** User-set justification values must be preserved
+4. **Property order:** Reference, Value, Footprint, Datasheet, Description, then custom properties
+5. **Empty values:** Description has empty string value but is still visible
+
+## Used For
+
+- **Testing:** Unit and reference tests for property visibility tracking
+- **Validation:** Round-trip preservation of all properties and visibility states
+- **Format preservation:** Ensuring `hidden_properties` set correctly maps to `(hide yes)` flags
+
+## Created
+
+- **Date:** 2025-11-08
+- **Issue:** #140
+- **PRD:** docs/prd/property-preservation-prd.md
+- **KiCAD Version:** 9.0 (version 20250114)

--- a/tests/reference_kicad_projects/property_preservation/test.kicad_sch
+++ b/tests/reference_kicad_projects/property_preservation/test.kicad_sch
@@ -1,0 +1,238 @@
+(kicad_sch
+	(version 20250114)
+	(generator "eeschema")
+	(generator_version "9.0")
+	(uuid "cf6911eb-0d2a-42a2-9dab-3dc3751a9616")
+	(paper "A4")
+	(title_block
+		(title "PropertyPreservationTest")
+	)
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 100.33 100.33 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9f05edb1-b153-4362-866d-3c06851c53fb")
+		(property "Reference" "R1"
+			(at 102.87 99.0599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "10k"
+			(at 102.87 101.5999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric"
+			(at 98.552 100.33 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 100.33 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 100.33 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "C0603FR-0710KL"
+			(at 100.33 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Manufacturer" "Yageo"
+			(at 100.33 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right top)
+			)
+		)
+		(property "Tolearnce" "1%"
+			(at 100.33 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(pin "1"
+			(uuid "dc1eecf2-7fad-4b78-becc-76c022d69840")
+		)
+		(pin "2"
+			(uuid "fb883bfc-b82e-4529-a000-73b770f3b8c0")
+		)
+		(instances
+			(project "PropertyPreservationTest"
+				(path "/cf6911eb-0d2a-42a2-9dab-3dc3751a9616"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
+	(embedded_fonts no)
+)

--- a/tests/reference_tests/test_property_preservation_reference.py
+++ b/tests/reference_tests/test_property_preservation_reference.py
@@ -1,0 +1,242 @@
+"""
+Reference tests for property preservation.
+
+Tests that validate exact format preservation against the manually-created
+reference schematic with custom properties and mixed visibility states.
+"""
+
+import pytest
+import kicad_sch_api as ksa
+
+
+@pytest.mark.format
+class TestPropertyPreservationReference:
+    """Test loading and preserving the property preservation reference schematic."""
+
+    def test_load_reference_schematic(self):
+        """Reference schematic should load without errors."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+
+        assert sch is not None
+        assert len(sch.components) == 1
+        assert sch.components.get("R1") is not None
+
+    def test_reference_component_properties(self):
+        """All properties from reference should be loaded."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Standard properties
+        assert r1.reference == "R1"
+        assert r1.value == "10k"
+        assert r1.footprint == "Resistor_SMD:R_0603_1608Metric"
+
+        # Properties dict should contain all properties
+        assert r1.properties["Datasheet"] == "~"
+        assert r1.properties["Description"] == ""
+        assert r1.properties["MPN"] == "C0603FR-0710KL"
+        assert r1.properties["Manufacturer"] == "Yageo"
+        assert r1.properties["Tolearnce"] == "1%"  # Typo from reference
+
+    def test_reference_hidden_properties_set(self):
+        """Hidden properties should be correctly identified."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # These have (hide yes) in reference
+        expected_hidden = {"Footprint", "Datasheet", "MPN"}
+
+        for prop in expected_hidden:
+            assert prop in r1.hidden_properties, f"{prop} should be hidden"
+
+    def test_reference_visible_properties_set(self):
+        """Visible properties should NOT be in hidden_properties."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # These do NOT have (hide yes) in reference
+        expected_visible = {"Reference", "Value", "Description", "Manufacturer", "Tolearnce"}
+
+        for prop in expected_visible:
+            # Check both in properties dict and NOT in hidden set
+            # Note: Reference and Value are special and stored as attributes
+            if prop in ["Reference", "Value"]:
+                # These are stored as attributes, not in properties dict
+                continue
+            else:
+                assert prop not in r1.hidden_properties, f"{prop} should be visible"
+
+    def test_reference_roundtrip_byte_perfect(self, tmp_path):
+        """Load → save should produce output matching reference (or semantically equivalent)."""
+        # Load reference
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+
+        # Save to temp
+        output_path = tmp_path / "roundtrip.kicad_sch"
+        sch.save(str(output_path))
+
+        # Reload and compare
+        sch2 = ksa.Schematic.load(str(output_path))
+        r1 = sch2.components.get("R1")
+
+        # Properties should match
+        assert r1.reference == "R1"
+        assert r1.value == "10k"
+        assert r1.footprint == "Resistor_SMD:R_0603_1608Metric"
+        assert r1.properties["MPN"] == "C0603FR-0710KL"
+        assert r1.properties["Manufacturer"] == "Yageo"
+        assert r1.properties["Tolearnce"] == "1%"
+
+        # Visibility should match
+        assert "MPN" in r1.hidden_properties
+        assert "Footprint" in r1.hidden_properties
+        assert "Datasheet" in r1.hidden_properties
+        assert "Manufacturer" not in r1.hidden_properties
+
+    def test_reference_sexp_preservation(self):
+        """S-expression structures should be preserved for all properties."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # All properties should have preserved S-expressions
+        expected_sexp_props = [
+            "Reference",
+            "Value",
+            "Footprint",
+            "Datasheet",
+            "Description",
+            "MPN",
+            "Manufacturer",
+            "Tolearnce",
+        ]
+
+        for prop_name in expected_sexp_props:
+            sexp_key = f"__sexp_{prop_name}"
+            assert sexp_key in r1.properties, f"Missing S-expression for {prop_name}"
+
+    def test_programmatic_recreation_of_reference(self):
+        """Programmatically create a component matching the reference."""
+        sch = ksa.create_schematic("PropertyPreservationTest")
+
+        # Create component
+        r1 = sch.components.add(
+            lib_id="Device:R",
+            reference="R1",
+            value="10k",
+            position=(100.33, 100.33),
+            footprint="Resistor_SMD:R_0603_1608Metric",
+        )
+
+        # Add custom properties with correct visibility
+        r1.add_property("Datasheet", "~", hidden=True)
+        r1.add_property("Description", "", hidden=False)
+        r1.add_property("MPN", "C0603FR-0710KL", hidden=True)
+        r1.add_property("Manufacturer", "Yageo", hidden=False)
+        r1.add_property("Tolearnce", "1%", hidden=False)
+
+        # Verify structure matches
+        assert r1.reference == "R1"
+        assert r1.value == "10k"
+        assert r1.properties["MPN"] == "C0603FR-0710KL"
+
+        # Verify visibility matches
+        assert "MPN" in r1.hidden_properties
+        assert "Datasheet" in r1.hidden_properties
+        assert "Manufacturer" not in r1.hidden_properties
+        assert "Tolearnce" not in r1.hidden_properties
+
+    def test_reference_property_count(self):
+        """Reference should have exactly 8 properties (including Reference, Value, Footprint)."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Count properties with S-expression preservation
+        sexp_props = [k for k in r1.properties.keys() if k.startswith("__sexp_")]
+
+        # Should have: Reference, Value, Footprint, Datasheet, Description, MPN, Manufacturer, Tolearnce
+        assert len(sexp_props) == 8
+
+    def test_reference_hidden_count(self):
+        """Reference should have exactly 3 hidden properties."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Should be: Footprint, Datasheet, MPN
+        assert len(r1.hidden_properties) == 3
+
+
+@pytest.mark.format
+class TestPropertyPreservationFileFormat:
+    """Test exact file format details."""
+
+    def test_hide_flag_format_in_reference(self):
+        """Reference file should use (hide yes) format, not (hide no)."""
+        with open(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch", "r"
+        ) as f:
+            content = f.read()
+
+        # Should contain (hide yes)
+        assert "(hide yes)" in content
+
+        # Should NOT contain (hide no) - KiCAD doesn't use this
+        assert "(hide no)" not in content
+
+    def test_property_ordering_in_reference(self):
+        """Properties should appear in standard order in file."""
+        with open(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch", "r"
+        ) as f:
+            content = f.read()
+
+        # Find property positions
+        ref_pos = content.find('property "Reference"')
+        val_pos = content.find('property "Value"')
+        fp_pos = content.find('property "Footprint"')
+        ds_pos = content.find('property "Datasheet"')
+        desc_pos = content.find('property "Description"')
+        mpn_pos = content.find('property "MPN"')
+
+        # Standard properties should come first
+        assert ref_pos < val_pos < fp_pos < ds_pos < desc_pos < mpn_pos
+
+    def test_effects_section_structure(self):
+        """Effects sections should have consistent structure."""
+        with open(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch", "r"
+        ) as f:
+            content = f.read()
+
+        # All properties should have effects section with font
+        assert content.count("(effects") >= 8  # One per property
+        # Font can be inline or multiline - just check for size
+        assert content.count("(size 1.27 1.27)") >= 8
+
+    def test_justification_preserved_in_reference(self):
+        """User-set justification should be preserved in reference."""
+        with open(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch", "r"
+        ) as f:
+            content = f.read()
+
+        # Manufacturer has (justify right top) - user set this
+        assert "(justify right top)" in content
+
+        # Tolearnce has (justify left bottom) - user set this
+        assert "(justify left bottom)" in content

--- a/tests/unit/test_property_visibility.py
+++ b/tests/unit/test_property_visibility.py
@@ -1,0 +1,383 @@
+"""
+Unit tests for component property visibility tracking.
+
+Tests the hidden_properties field and helper methods for managing
+property visibility state during load, save, and programmatic modification.
+"""
+
+import pytest
+import kicad_sch_api as ksa
+from kicad_sch_api.core.types import SchematicSymbol, Point
+
+
+class TestPropertyVisibilityLoading:
+    """Test that property visibility state is extracted during load."""
+
+    def test_load_extracts_hidden_properties(self):
+        """Hidden properties should be identified and added to hidden_properties set."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Properties with (hide yes) should be in hidden_properties set
+        assert "Footprint" in r1.hidden_properties
+        assert "Datasheet" in r1.hidden_properties
+        assert "MPN" in r1.hidden_properties
+
+    def test_load_identifies_visible_properties(self):
+        """Visible properties should NOT be in hidden_properties set."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Properties without hide flag should NOT be in set
+        assert "Reference" not in r1.hidden_properties
+        assert "Value" not in r1.hidden_properties
+        assert "Manufacturer" not in r1.hidden_properties
+        assert "Tolearnce" not in r1.hidden_properties  # Typo preserved from reference
+
+    def test_all_properties_loaded(self):
+        """All properties should be loaded regardless of visibility."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Check all properties are in dict
+        assert r1.properties["Datasheet"] == "~"
+        assert r1.properties["MPN"] == "C0603FR-0710KL"
+        assert r1.properties["Manufacturer"] == "Yageo"
+        assert r1.properties["Tolearnce"] == "1%"
+        assert r1.properties["Description"] == ""  # Empty value
+
+    def test_hidden_properties_field_exists(self):
+        """SchematicSymbol should have hidden_properties field."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Field should exist and be a set
+        assert hasattr(r1, "hidden_properties")
+        assert isinstance(r1.hidden_properties, set)
+
+
+class TestPropertyVisibilityRoundTrip:
+    """Test that visibility state survives round-trip load → save → load."""
+
+    def test_hidden_properties_preserved_on_save(self, tmp_path):
+        """Hidden properties should have (hide yes) flag after save."""
+        # Load reference
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+
+        # Save to temp file
+        output_path = tmp_path / "roundtrip.kicad_sch"
+        sch.save(str(output_path))
+
+        # Reload
+        sch2 = ksa.Schematic.load(str(output_path))
+        r1 = sch2.components.get("R1")
+
+        # Hidden properties should still be hidden
+        assert "Footprint" in r1.hidden_properties
+        assert "Datasheet" in r1.hidden_properties
+        assert "MPN" in r1.hidden_properties
+
+    def test_visible_properties_preserved_on_save(self, tmp_path):
+        """Visible properties should NOT have hide flag after save."""
+        # Load reference
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+
+        # Save to temp file
+        output_path = tmp_path / "roundtrip.kicad_sch"
+        sch.save(str(output_path))
+
+        # Reload
+        sch2 = ksa.Schematic.load(str(output_path))
+        r1 = sch2.components.get("R1")
+
+        # Visible properties should still be visible
+        assert "Reference" not in r1.hidden_properties
+        assert "Value" not in r1.hidden_properties
+        assert "Manufacturer" not in r1.hidden_properties
+
+    def test_property_values_unchanged_after_roundtrip(self, tmp_path):
+        """Property values should not change during round-trip."""
+        # Load reference
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+
+        # Save and reload
+        output_path = tmp_path / "roundtrip.kicad_sch"
+        sch.save(str(output_path))
+        sch2 = ksa.Schematic.load(str(output_path))
+        r1 = sch2.components.get("R1")
+
+        # Values should be identical
+        assert r1.properties["MPN"] == "C0603FR-0710KL"
+        assert r1.properties["Manufacturer"] == "Yageo"
+        assert r1.properties["Tolearnce"] == "1%"
+        assert r1.properties["Datasheet"] == "~"
+
+
+class TestAddPropertyMethod:
+    """Test the add_property() helper method."""
+
+    def test_add_property_hidden(self):
+        """Adding property with hidden=True should add to hidden_properties."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        # Add hidden property
+        r1.add_property("Supplier", "Digikey", hidden=True)
+
+        assert r1.properties["Supplier"] == "Digikey"
+        assert "Supplier" in r1.hidden_properties
+
+    def test_add_property_visible(self):
+        """Adding property with hidden=False should NOT add to hidden_properties."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        # Add visible property
+        r1.add_property("Notes", "Important resistor", hidden=False)
+
+        assert r1.properties["Notes"] == "Important resistor"
+        assert "Notes" not in r1.hidden_properties
+
+    def test_add_property_default_visible(self):
+        """Default hidden parameter should be False (visible)."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        # Add property without specifying hidden
+        r1.add_property("TestProp", "TestValue")
+
+        assert r1.properties["TestProp"] == "TestValue"
+        assert "TestProp" not in r1.hidden_properties
+
+    def test_add_property_update_existing(self):
+        """Adding property that exists should update value and visibility."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        # Add initially hidden
+        r1.add_property("MPN", "OLD_VALUE", hidden=True)
+        assert "MPN" in r1.hidden_properties
+
+        # Update to visible with new value
+        r1.add_property("MPN", "NEW_VALUE", hidden=False)
+
+        assert r1.properties["MPN"] == "NEW_VALUE"
+        assert "MPN" not in r1.hidden_properties
+
+
+class TestAddPropertiesMethod:
+    """Test the add_properties() bulk helper method."""
+
+    def test_add_properties_hidden(self):
+        """Adding multiple properties with hidden=True."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        props = {
+            "MPN": "RC0603FR-0710KL",
+            "Manufacturer": "Yageo",
+            "Supplier": "Digikey",
+        }
+        r1.add_properties(props, hidden=True)
+
+        # All properties should be added and hidden
+        assert r1.properties["MPN"] == "RC0603FR-0710KL"
+        assert r1.properties["Manufacturer"] == "Yageo"
+        assert r1.properties["Supplier"] == "Digikey"
+
+        assert "MPN" in r1.hidden_properties
+        assert "Manufacturer" in r1.hidden_properties
+        assert "Supplier" in r1.hidden_properties
+
+    def test_add_properties_visible(self):
+        """Adding multiple properties with hidden=False."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        props = {
+            "Notes": "High precision",
+            "Category": "Passive",
+        }
+        r1.add_properties(props, hidden=False)
+
+        # All properties should be added and visible
+        assert r1.properties["Notes"] == "High precision"
+        assert r1.properties["Category"] == "Passive"
+
+        assert "Notes" not in r1.hidden_properties
+        assert "Category" not in r1.hidden_properties
+
+    def test_add_properties_default_visible(self):
+        """Default hidden parameter should be False (visible)."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        props = {"Prop1": "Value1", "Prop2": "Value2"}
+        r1.add_properties(props)
+
+        assert "Prop1" not in r1.hidden_properties
+        assert "Prop2" not in r1.hidden_properties
+
+
+class TestVisibilityToggling:
+    """Test changing visibility of existing properties."""
+
+    def test_hide_existing_property(self):
+        """Adding property to hidden_properties should hide it."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Manufacturer is initially visible
+        assert "Manufacturer" not in r1.hidden_properties
+
+        # Hide it
+        r1.hidden_properties.add("Manufacturer")
+
+        assert "Manufacturer" in r1.hidden_properties
+
+    def test_show_existing_property(self):
+        """Removing property from hidden_properties should show it."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # MPN is initially hidden
+        assert "MPN" in r1.hidden_properties
+
+        # Show it
+        r1.hidden_properties.discard("MPN")
+
+        assert "MPN" not in r1.hidden_properties
+
+    def test_visibility_change_survives_save(self, tmp_path):
+        """Visibility changes should persist after save."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Hide Manufacturer (was visible)
+        r1.hidden_properties.add("Manufacturer")
+
+        # Show MPN (was hidden)
+        r1.hidden_properties.discard("MPN")
+
+        # Save and reload
+        output_path = tmp_path / "toggled.kicad_sch"
+        sch.save(str(output_path))
+        sch2 = ksa.Schematic.load(str(output_path))
+        r1_reloaded = sch2.components.get("R1")
+
+        # Changes should persist
+        assert "Manufacturer" in r1_reloaded.hidden_properties
+        assert "MPN" not in r1_reloaded.hidden_properties
+
+
+class TestEdgeCases:
+    """Test edge cases for property visibility."""
+
+    def test_empty_property_value(self):
+        """Properties with empty values should be handled correctly."""
+        sch = ksa.Schematic.load(
+            "tests/reference_kicad_projects/property_preservation/test.kicad_sch"
+        )
+        r1 = sch.components.get("R1")
+
+        # Description has empty value
+        assert r1.properties["Description"] == ""
+        # It's visible in reference
+        assert "Description" not in r1.hidden_properties
+
+    def test_special_characters_in_property_value(self):
+        """Properties with special characters should be preserved."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        # Add property with quotes
+        r1.add_property("Notes", 'Use "high quality" parts', hidden=False)
+
+        assert r1.properties["Notes"] == 'Use "high quality" parts'
+
+    def test_property_not_in_hidden_set_if_never_added(self):
+        """Newly created components should have empty hidden_properties set."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        # Should have empty set by default
+        assert isinstance(r1.hidden_properties, set)
+        assert len(r1.hidden_properties) == 0
+
+    def test_delete_property_should_remove_from_hidden_set(self):
+        """Deleting a property should also clean up hidden_properties."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        r1.add_property("TempProp", "TempValue", hidden=True)
+        assert "TempProp" in r1.hidden_properties
+
+        # Delete property
+        del r1.properties["TempProp"]
+        r1.hidden_properties.discard("TempProp")
+
+        assert "TempProp" not in r1.properties
+        assert "TempProp" not in r1.hidden_properties
+
+
+@pytest.mark.format
+class TestFormatPreservation:
+    """Test that S-expression format is preserved correctly."""
+
+    def test_hide_flag_present_for_hidden_properties(self, tmp_path):
+        """Hidden properties should have (hide yes) in saved file."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+        r1.add_property("MPN", "TEST_MPN", hidden=True)
+
+        output_path = tmp_path / "test_hide.kicad_sch"
+        sch.save(str(output_path))
+
+        # Read raw file and check for hide flag
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        # Should contain (hide yes) for MPN property
+        assert "(hide yes)" in content
+        assert 'property "MPN" "TEST_MPN"' in content
+
+    def test_no_hide_flag_for_visible_properties(self, tmp_path):
+        """Visible properties should NOT have (hide yes) in saved file."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+        r1.add_property("Notes", "Important", hidden=False)
+
+        output_path = tmp_path / "test_visible.kicad_sch"
+        sch.save(str(output_path))
+
+        # Read raw file
+        with open(output_path, "r") as f:
+            content = f.read()
+
+        # Find the Notes property section
+        notes_start = content.find('property "Notes"')
+        notes_end = content.find(")", notes_start + 200)  # Find closing paren
+        notes_section = content[notes_start:notes_end]
+
+        # Should NOT contain hide flag
+        assert "(hide yes)" not in notes_section


### PR DESCRIPTION
## Summary

Fixes component property visibility preservation during round-trip operations (load → save → load).

## Changes

- Added `hidden_properties` set to track property visibility state
- Parser extracts `(hide yes)` flags from property S-expressions
- Formatter emits hide flags based on `hidden_properties` set
- Standard properties (Datasheet, Description) default to hidden
- New API: `component.add_property(name, value, hidden=True/False)`

## Testing

- 23 unit tests for property visibility API
- 13 reference tests against manually created KiCAD schematic
- All 36 new tests passing

## Validation

Manually verified in KiCAD 9.0 - properties show/hide correctly with proper eye icon indicators.

Closes #140