### PR TITLE
fix(#111): Add all() method to BaseCollection for MCP compatibility

### DIFF
--- a/kicad_sch_api/collections/base.py
+++ b/kicad_sch_api/collections/base.py
@@ -449,6 +449,23 @@ class BaseCollection(Generic[T], ABC):
 
         return self.find(matches_criteria)
 
+    def all(self) -> Iterator[T]:
+        """
+        Get iterator over all items in the collection.
+
+        Returns:
+            Iterator over all items
+
+        Example:
+            # Iterate over all components
+            for component in sch.components.all():
+                print(component.reference)
+
+            # Convert to list
+            all_components = list(sch.components.all())
+        """
+        return iter(self._items)
+
     def clear(self) -> None:
         """Clear all items from the collection."""
         self._items.clear()


### PR DESCRIPTION
## Summary
Fixes issue #111 where the MCP `load_schematic` and `get_schematic_info` tools fail with:
```
AttributeError: 'ComponentCollection' object has no attribute 'all'
```

## Root Cause
The MCP server calls `schematic.components.all()` in two critical places:
1. **load_schematic** (line 150) - `component_count = len(list(schematic.components.all()))`
2. **get_schematic_info** (line 266) - `components = list(schematic.components.all())`

But `BaseCollection` didn't have an `all()` method.

## Solution
Added the `all()` method to `BaseCollection` that returns an `Iterator[T]` over all items.

### Implementation (17 lines)
```python
def all(self) -> Iterator[T]:
    """
    Get iterator over all items in the collection.
    
    Returns:
        Iterator over all items
    """
    return iter(self._items)
```

## Verification ✅

### Direct Code Path Testing
Verified the exact MCP code paths that were failing now work:

**Test 1: load_schematic flow (line 150)**
```
component_count = len(list(schematic.components.all()))
✅ SUCCESS! component_count = 3
```

**Test 2: get_schematic_info flow (line 266)**
```
components = list(schematic.components.all())
✅ SUCCESS! Found 3 components
References: ['R1', 'C1', 'L1']
```

### Test Coverage
- ✅ Empty collection
- ✅ Single component
- ✅ Multiple components
- ✅ Round-trip schematic load/save

## Impact
- **Breaking changes:** None - this is a pure addition
- **API stability:** Backward compatible
- **Performance:** No impact - returns existing iterator

## Related
- Closes #111
- Tested against actual MCP server code paths (lines 150 and 266)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>