### PR TITLE
chore: Restructure Claude infrastructure with domain-specific commands

### DIFF
--- a/.claude/commands/dev/dead-code-analysis.md
+++ b/.claude/commands/dev/dead-code-analysis.md
@@ -1,0 +1,220 @@
+# Dead Code Analysis Command - kicad-sch-api
+
+## Usage
+```
+/dead-code-analysis [target-script]
+```
+
+## Description
+Performs comprehensive dead code analysis for kicad-sch-api by running ALL functionality and observing which functions are actually called. This provides accurate utilization metrics by exercising:
+
+1. **Core Schematic Operations** - Load, save, component management, validation
+2. **S-Expression Parsing** - All parsing and formatting functionality  
+3. **Component Collections** - Filtering, bulk operations, indexing
+4. **Symbol Library Management** - Caching, discovery, multi-source lookup
+5. **MCP Server Integration** - All MCP tools and Python bridge
+6. **Validation Systems** - Error collection, comprehensive validation
+7. **Format Preservation** - Round-trip testing, exact output matching
+8. **Performance Systems** - Caching, optimization, benchmarking
+
+## Parameters
+- `target-script` (optional): Path to script to run for function call analysis. Defaults to comprehensive test suite.
+- `--comprehensive`: Runs full system functionality test (default behavior)
+
+## Output Files
+- `function_calls.log`: Raw debug output from script execution
+- `unique_function_calls.txt`: List of unique functions that were called
+- `Dead_Code_Analysis_Report.md`: Comprehensive analysis report
+- `*.backup`: Backup files for all instrumented source files
+
+## Examples
+```bash
+# Analyze dead code using comprehensive test suite
+/dead-code-analysis
+
+# Analyze using specific test script
+/dead-code-analysis tests/test_comprehensive_operations.py
+
+# Analyze using MCP server test
+/dead-code-analysis tests/test_mcp_integration.py
+```
+
+## Implementation for kicad-sch-api
+The command performs the following automated steps:
+
+### 1. Function Instrumentation
+- Scans all Python files in `kicad_sch_api/`
+- Adds `logging.debug(f"CALLED: {function_name} in {file_path}")` to every function
+- Creates backup files (`.backup`) before modification
+- Preserves existing function logic and formatting
+
+### 2. Comprehensive Testing
+- Runs test scripts covering all major functionality areas
+- Captures function calls during real usage scenarios
+- Tests both Python API and MCP server integration
+
+### 3. Analysis & Reporting
+- Extracts unique function calls from execution log
+- Compares against all instrumented functions
+- Groups suspected dead code by module
+- Generates comprehensive markdown report
+
+## kicad-sch-api Test Coverage Areas
+
+### Core Library Testing
+```python
+# test_comprehensive_kicad_sch_api.py
+import kicad_sch_api as ksa
+
+def test_core_schematic_operations():
+    """Test all core schematic functionality"""
+    
+    # File operations
+    sch = ksa.create_schematic("Dead Code Test")
+    
+    # Component management
+    components = []
+    for i in range(20):
+        comp = sch.components.add(f"Device:R", f"R{i+1}", f"{i+1}k", (i*10, 50))
+        comp.set_property("MPN", f"RC0603FR-07{i+1}0KL")
+        components.append(comp)
+    
+    # Filtering and search
+    resistors = sch.components.filter(lib_id="Device:R")
+    high_value = sch.components.filter(value_pattern="k")
+    in_area = sch.components.in_area(0, 40, 100, 60)
+    
+    # Bulk operations
+    sch.components.bulk_update(
+        criteria={'lib_id': 'Device:R'},
+        updates={'properties': {'Tolerance': '1%'}}
+    )
+    
+    # Validation
+    issues = sch.validate()
+    
+    # Performance stats
+    stats = sch.get_performance_stats()
+    
+    return sch
+
+def test_symbol_library_comprehensive():
+    """Test all symbol library functionality"""
+    from kicad_sch_api.library.cache import get_symbol_cache
+    
+    cache = get_symbol_cache()
+    
+    # Library discovery
+    discovered = cache.discover_libraries()
+    
+    # Symbol search
+    symbols = cache.search_symbols("resistor", limit=10)
+    
+    # Performance metrics
+    perf_stats = cache.get_performance_stats()
+    
+    # Library management
+    cache.add_library_path("/some/test/path.kicad_sym")
+    
+    return cache
+
+def test_parser_and_formatter():
+    """Test all parsing and formatting functionality"""
+    from kicad_sch_api.core.parser import SExpressionParser
+    from kicad_sch_api.core.formatter import ExactFormatter
+    
+    parser = SExpressionParser(preserve_format=True)
+    formatter = ExactFormatter()
+    
+    # Test parsing
+    test_content = '''(kicad_sch (version 20250114) 
+        (symbol (lib_id "Device:R") (at 100 50 0)
+            (property "Reference" "R1" (at 100 46.99 0))
+        ))'''
+    
+    parsed = parser.parse_string(test_content)
+    formatted = formatter.format(parsed)
+    
+    return parser, formatter
+
+def test_validation_comprehensive():
+    """Test all validation functionality"""
+    from kicad_sch_api.utils.validation import SchematicValidator, validate_schematic_file
+    
+    validator = SchematicValidator(strict=True)
+    
+    # Test all validation methods
+    valid_ref = validator.validate_reference("R1")
+    invalid_ref = validator.validate_reference("1R")
+    valid_lib = validator.validate_lib_id("Device:R") 
+    invalid_lib = validator.validate_lib_id("InvalidFormat")
+    
+    return validator
+```
+
+### MCP Server Testing
+```python
+def test_mcp_server_comprehensive():
+    """Test all MCP server functionality"""
+    from kicad_sch_api.mcp.server import MCPInterface
+    
+    mcp = MCPInterface()
+    
+    # Test all MCP commands
+    commands = [
+        ('ping', {}),
+        ('create_schematic', {'name': 'MCP Test'}),
+        ('add_component', {
+            'lib_id': 'Device:R', 
+            'reference': 'R1', 
+            'value': '10k',
+            'position': {'x': 100, 'y': 50}
+        }),
+        ('get_component', {'reference': 'R1'}),
+        ('find_components', {'lib_id': 'Device:R'}),
+        ('validate_schematic', {}),
+        ('get_schematic_summary', {}),
+    ]
+    
+    for command, params in commands:
+        try:
+            result = mcp.handlers[command](params)
+            print(f"✅ MCP command: {command}")
+        except Exception as e:
+            print(f"⚠️ MCP command {command} failed: {e}")
+    
+    return mcp
+```
+
+## Expected Results for kicad-sch-api
+
+With comprehensive testing, expect these utilization rates:
+- **Core schematic operations**: 85-95%
+- **Component management**: 80-90%
+- **S-expression parsing**: 70-85%
+- **Symbol library caching**: 60-75%
+- **MCP server integration**: 70-85%
+- **Validation systems**: 60-80%
+- **Utility functions**: 40-60%
+
+## Target Test Scripts
+
+1. **test_comprehensive_kicad_sch_api.py** - Core API functionality
+2. **test_mcp_server_integration.py** - MCP server and tools
+3. **test_performance_benchmarks.py** - Large schematic handling
+4. **test_format_preservation.py** - Round-trip validation
+5. **test_reference_schematics.py** - All reference project parsing
+
+## Safety Notes
+- Creates backup files before modifying source code
+- Only adds logging statements, doesn't change logic
+- Can be run multiple times safely
+- Restore backups: `find . -name "*.backup" | while read backup; do mv "$backup" "${backup%.backup}"; done`
+
+## Implementation Path
+```bash
+# From kicad-sch-api/python directory
+python .claude/commands/dev/dead-code-analysis.py [target-script]
+```
+
+This analysis will help identify which parts of the transferred circuit-synth logic are actually being used vs. which can be safely removed or refactored.

--- a/.claude/commands/dev/dev.md
+++ b/.claude/commands/dev/dev.md
@@ -1,0 +1,1313 @@
+---
+description: Core development workflow - from problem to PR for KiCAD schematic features
+---
+
+# /dev - Development Workflow for KiCAD Schematic API
+
+**Purpose**: Complete development workflow from problem description to pull request, using KiCAD reference-driven development with comprehensive testing and format preservation validation.
+
+**Use when**: Building features, fixing bugs, or adding functionality that requires systematic development with PRD, reference schematics, tests, and iterative implementation.
+
+---
+
+## Workflow Overview
+
+```
+/dev (end-to-end development)
+  ├─ Phase 1: Generate PRD (research → ask questions → document)
+  │   └─ STOP: User reviews PRD
+  ├─ Phase 2: Create Reference Schematic (Interactive - agent creates, user refines)
+  │   └─ STOP: User edits in KiCAD, says "done"
+  ├─ Phase 3: Generate Tests (autonomous - no stop)
+  ├─ Phase 4: Implementation (autonomous + communicative - shows progress)
+  │   └─ STOP if stuck after 8 iterations
+  ├─ Phase 4.5: Manual Validation (Interactive - agent guides, user inspects)
+  │   └─ STOP: User validates in KiCAD
+  └─ Phase 5: Cleanup & PR (autonomous - no stop)
+```
+
+**Time estimate**: 1-4 hours depending on complexity
+
+---
+
+## Reviewing and Fixing Existing PRs
+
+**If you encounter an existing PR with failing CI**, follow these steps to fix it:
+
+### Step 1: Checkout the PR branch
+```bash
+gh pr checkout {PR_NUMBER}
+```
+
+### Step 2: Fix formatting issues
+```bash
+# Format code
+uv run black kicad_sch_api/ tests/
+uv run isort kicad_sch_api/ tests/
+```
+
+### Step 3: Fix other CI failures
+```bash
+# Run tests to identify failures
+uv run pytest tests/ -v
+
+# Fix type errors
+uv run mypy kicad_sch_api/
+
+# Fix linting issues
+uv run flake8 kicad_sch_api/ tests/
+```
+
+### Step 4: Commit and push fixes
+```bash
+git add -A
+git commit -m "chore: Fix CI formatting and test failures
+
+Apply black and isort formatting to pass CI checks.
+Fix any test failures and type errors.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+git push origin {BRANCH_NAME}
+```
+
+### Step 5: Resolve merge conflicts (if needed)
+```bash
+# Fetch and merge main
+git fetch origin main
+git merge origin/main
+
+# Resolve conflicts manually or use preferred versions:
+# - Use theirs for files unrelated to the PR's purpose
+# - Manually resolve conflicts in PR-specific changes
+
+git add {resolved_files}
+git commit -m "Merge branch 'main' into {branch_name}"
+git push origin {BRANCH_NAME}
+```
+
+### Step 6: Merge the PR
+```bash
+# Squash merge (preferred for clean history)
+gh pr merge {PR_NUMBER} --squash --delete-branch
+
+# Or regular merge if history preservation needed
+gh pr merge {PR_NUMBER} --merge --delete-branch
+```
+
+**Key Principle**: ALWAYS fix CI locally before pushing. Never leave a PR with failing checks.
+
+---
+
+## Usage
+
+```bash
+# Format preservation bug
+/dev "Pin UUIDs not preserved during round-trip load/save"
+
+# New element support
+/dev "Add support for text box elements with borders and margins"
+```
+
+---
+
+## Phase 1: Generate PRD
+
+**Goal**: Create comprehensive Product Requirements Document
+
+### Step 1.1: Research and Analyze (Silent)
+
+**Before asking questions**, do research to understand context:
+
+1. **Search codebase** for related functionality:
+   - Use Grep/Glob to find similar features
+   - Read relevant parser/formatter files
+   - Check existing tests for patterns
+   - Review related PRDs in `docs/prd/`
+
+2. **Understand the problem domain**:
+   - What KiCAD elements are involved?
+   - What S-expression format is affected?
+   - What existing code handles similar cases?
+   - What reference schematics exist that might help?
+
+3. **Identify knowledge gaps**:
+   - What can't be determined from code alone?
+   - What requires user preference/decision?
+   - What scope clarification is needed?
+   - What technical constraints are unclear?
+
+**DO NOT present research findings to user** - use this to formulate smart questions.
+
+### Step 1.2: Ask Clarifying Questions
+
+**After research**, ask targeted questions to fill knowledge gaps:
+
+**Question Guidelines**:
+- **Maximum 5 questions** unless user explicitly requests more detail
+- **Keep concise** - use bullet points, not paragraphs
+- **Be specific** - reference code/files found during research
+- **Offer options** when possible (makes answering easier)
+- **Skip obvious** - if you can infer from code, don't ask
+- **Focus on**: scope clarification, user preferences, architectural decisions, edge case handling
+
+**Wait for user responses** before proceeding.
+
+### Step 1.3: Generate PRD
+
+**IMPORTANT - Writing Guidelines**: Follow `CLAUDE.md` - NO marketing language, engineer tone, specific technical claims only.
+
+**PRD Structure** (save to `docs/prd/{feature-name}-prd.md`):
+- Overview (what we're building - technical and specific)
+- Success Criteria (measurable checkboxes)
+- Functional Requirements (numbered list)
+- KiCAD Format Specifications (S-expression structure, version compatibility, preservation requirements)
+- Technical Constraints (backward compatibility, format preservation)
+- Reference Schematic Requirements (what to create, expected format)
+- Edge Cases (specific scenarios and handling)
+- Impact Analysis (parser/formatter/type/MCP changes)
+- Out of Scope
+- Acceptance Criteria (includes "All tests pass", "Format preservation validated")
+
+### Step 1.4: User Checkpoint
+
+**Present PRD and ask**:
+> I've created a PRD for this feature. Please review:
+>
+> [Show PRD]
+>
+> Does this accurately capture what we're building? Any missing requirements or concerns?
+
+**Wait for user approval** before proceeding to Phase 2.
+
+---
+
+## Phase 2: Create Reference Schematic (Interactive)
+
+**Goal**: Create KiCAD reference schematic that demonstrates the feature/behavior
+
+This is a **critical phase** - the reference schematic becomes the source of truth for exact KiCAD format.
+
+### Step 2.0: Trusted Actions Decision
+
+**Decide who creates reference**:
+- **Agent creates** (most common): Testing format preservation, new elements, API behavior. Agent can reliably use `add_component()`, `add_wire()`, `add_label()`, etc.
+- **Human creates** (rare): Testing those APIs themselves, or when aesthetics matter.
+
+### Step 2.1: Create Initial Schematic
+
+**Agent creates schematic** with elements from PRD. **IMPORTANT: Keep references MINIMAL - one component per reference schematic whenever possible.** This makes debugging easier, tests clearer, and references more focused.
+
+**Reference Schematic Guidelines:**
+- **One component per schematic** - simpler is better
+- **Minimal elements** - only what's needed to demonstrate the feature
+- **Grid-aligned positions** (multiples of 1.27mm)
+- **Generic positioning** like (100, 100) - functional > beautiful
+- **Multiple references** - create separate schematics for different test cases rather than one complex schematic
+
+If human should create: provide blank schematic instead.
+
+**Tell user** what was created and open in KiCAD for optional refinement.
+
+### Step 2.2: Open for User Editing
+
+**Claude opens schematic**:
+```bash
+open /tmp/{feature_name}_working.kicad_sch
+```
+
+**Tell user**:
+> I've created an initial schematic at `/tmp/{feature_name}_working.kicad_sch` and opened it in KiCAD.
+>
+> Please:
+> 1. Review/adjust the schematic to demonstrate the feature
+> 2. Add any missing elements (components, wires, labels, properties, pins)
+> 3. Ensure positions are clean and layout is readable
+> 4. **For format preservation bugs**: Make sure the element exists with all required fields
+> 5. Save the schematic (Cmd+S / Ctrl+S)
+> 6. Tell me "saved" or "done" when ready
+>
+> What I've included so far:
+> {List components, wires, labels, etc. that were pre-created}
+
+### Step 2.3: User Edits in KiCAD
+
+**User performs manual editing**:
+- Add/modify components, wires, labels, properties
+- Adjust positioning for clarity
+- Add edge cases or variations
+- Ensure schematic demonstrates the feature being developed
+- **Save changes** in KiCAD
+
+**User signals completion**: "saved", "done", or similar
+
+### Step 2.4: Claude Analyzes and Copies Reference
+
+**Claude processes the saved schematic**:
+
+1. **Read the user-saved schematic**:
+   ```python
+   sch = ksa.Schematic.load("/tmp/{feature_name}_working.kicad_sch")
+   ```
+
+2. **Analyze what user created**:
+   ```python
+   # Log what's in the schematic
+   print(f"Components: {len(sch.components)}")
+   print(f"Wires: {len(sch.wires)}")
+   print(f"Labels: {len(sch.labels)}")
+   # etc.
+   ```
+
+3. **Parse S-expression to understand exact format**:
+   ```python
+   # Read raw file to see exact S-expression structure
+   with open("/tmp/{feature_name}_working.kicad_sch", 'r') as f:
+       raw_content = f.read()
+
+   # Identify the specific S-expression structure for the feature
+   # This becomes the format we must replicate
+   ```
+
+4. **Determine reference location**:
+   - Ask user: "Where should I save this reference? Suggestions: `tests/reference_kicad_projects/{feature_name}/` or `tests/reference_kicad_projects/{custom_name}/`?"
+   - Or propose a name based on the feature
+
+5. **Copy to reference location**:
+   ```bash
+   mkdir -p tests/reference_kicad_projects/{reference_name}
+   cp /tmp/{feature_name}_working.kicad_sch tests/reference_kicad_projects/{reference_name}/test.kicad_sch
+   ```
+
+6. **Create README for reference**:
+   ```markdown
+   # Reference: {Feature Name}
+
+   ## Purpose
+   {What this reference schematic demonstrates}
+
+   ## Contents
+   - Components: {list}
+   - Wires: {count}
+   - Labels: {count}
+   - {Other elements}
+
+   ## Key S-expression Format
+   ```
+   {Show relevant S-expression snippet}
+   ```
+
+   ## Used For
+   - Testing: {which tests use this}
+   - Validation: {what format preservation this validates}
+   - Training: {potential future ML/comparison use}
+
+   ## Created
+   Date: {date}
+   Issue: #{issue_number}
+   PRD: docs/prd/{feature-name}-prd.md
+   ```
+
+### Step 2.5: Reference Analysis Summary
+
+**Analyze and summarize reference** (informational):
+> ✅ Reference schematic created and saved to `tests/reference_kicad_projects/{reference_name}/`
+>
+> **Contents**:
+> - {N} components
+> - {M} wires
+> - {K} labels
+> - {Other elements}
+>
+> **Key Format Discovered**:
+> ```
+> {Show relevant S-expression snippet}
+> ```
+>
+> This reference will be used to:
+> 1. Understand exact KiCAD format requirements
+> 2. Guide implementation to match byte-perfect output
+> 3. Validate format preservation in tests
+>
+> Proceeding to test generation...
+
+---
+
+## Phase 3: Generate Tests
+
+**Goal**: Create comprehensive test suite from PRD and reference schematic
+
+### Step 3.1: Analyze Requirements and Reference
+
+**Extract from PRD**:
+- All functional requirements
+- All acceptance criteria
+- All edge cases
+- Format preservation requirements
+
+**Extract from Reference Schematic**:
+- Exact S-expression format to replicate
+- Element properties and structure
+- Expected values and types
+
+### Step 3.2: Generate Test Plan
+
+**Create test files**:
+- **Unit tests** (`tests/unit/test_{feature}.py`): Basic functionality, edge cases (empty/null values), round-trip preservation
+- **Reference tests** (`tests/reference_tests/test_{feature}_reference.py`): Parse reference schematic, exact format preservation (load→save→compare), programmatic replication
+- **Integration tests** (if needed): Connectivity analysis, MCP tools compatibility
+
+**Use pytest markers**: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.format` (CRITICAL for format preservation), `@pytest.mark.validation`
+
+### Step 3.3: Verify Test Coverage
+
+Map each test to PRD requirements. Ensure all functional requirements, edge cases, and acceptance criteria have corresponding tests.
+
+### Step 3.4: Test Summary (Informational)
+
+**Summarize test coverage** (informational - no approval needed):
+> ✅ Test suite created with {X} tests:
+>
+> **Unit Tests** ({N} tests):
+> - Basic functionality
+> - Edge cases
+> - Round-trip preservation
+>
+> **Reference Tests** ({M} tests):
+> - Parse reference schematic
+> - Exact format preservation
+> - Programmatic replication
+>
+> **Integration Tests** ({K} tests, if applicable):
+> - Connectivity integration
+> - MCP tools integration
+>
+> **Requirement Coverage**:
+> - [x] REQ-1: {requirement}
+> - [x] REQ-2: {requirement}
+> - All {N} requirements covered
+>
+> Proceeding to implementation...
+
+---
+
+## Phase 4: Implementation (Reference-Driven & Iterative)
+
+**Goal**: Implement solution that passes all tests and preserves exact KiCAD format
+
+### Step 4.1: Add Strategic Logging
+
+**Add comprehensive debug logging** using Python's logging module:
+
+**Parser logging** (`kicad_sch_api/parsers/elements/`):
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+def _parse_element(self, item):
+    """Parse element from S-expression."""
+    logger.debug(f"Parsing {element_type}: {item}")
+
+    # Parse fields
+    for sub_item in item[1:]:
+        element_type = str(sub_item[0])
+        logger.debug(f"  Field: {element_type} = {sub_item[1:] if len(sub_item) > 1 else None}")
+
+    # Log parsed result
+    logger.debug(f"Parsed {element_type}: {result}")
+    return result
+```
+
+**Formatter logging** (`kicad_sch_api/parsers/elements/`):
+```python
+def _element_to_sexp(self, element_data):
+    """Convert element to S-expression."""
+    logger.debug(f"Formatting {element_type}: {element_data}")
+
+    # Build S-expression
+    sexp = [Symbol(element_type)]
+
+    # Log each added field
+    for field_name, field_value in element_data.items():
+        logger.debug(f"  Adding field: {field_name} = {field_value}")
+        sexp.append(...)
+
+    logger.debug(f"Generated S-expression: {sexp}")
+    return sexp
+```
+
+**Data transformation logging**:
+```python
+# Type conversions
+logger.debug(f"Converting position: tuple {pos} -> Point({pos.x}, {pos.y})")
+
+# UUID handling
+logger.debug(f"Preserving UUID: {uuid} for {element_type}")
+
+# Format decisions
+logger.debug(f"Using format: byte-perfect vs semantic (decided: {format_type})")
+```
+
+**Logging Principles for Python**:
+- ✅ **DO**: Use `logger.debug()` for development insights
+- ✅ **DO**: Use `logger.warning()` for format deviations or unexpected values
+- ✅ **DO**: Use `logger.error()` for parsing/formatting failures
+- ✅ **DO**: Include context (element type, field name, values)
+- ❌ **DON'T**: Use `print()` statements
+- ❌ **DON'T**: Log inside tight loops (performance)
+- ❌ **DON'T**: Log sensitive data
+
+**Enable debug logging during development**:
+```python
+# In test file or main script
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+### Step 4.2: Iterative Development Loop (Communicative + Log-Driven)
+
+**IMPORTANT**: Be communicative during iteration so human can follow along and interrupt if needed.
+
+**At start of implementation, explain approach**:
+> Starting implementation for {feature}. My approach based on PRD:
+>
+> 1. **Parser changes** (PRD Section X.Y):
+>    - Extract {field} from S-expression
+>    - Handle edge case: {specific edge case}
+>
+> 2. **Type changes** (PRD Section X.Z):
+>    - Add {field} to {dataclass}
+>
+> 3. **Formatter changes** (PRD Section X.W):
+>    - Emit {field} in KiCAD format: `({element} {structure})`
+>
+> Running tests to establish baseline...
+
+**Iteration cycle** (repeat until tests pass):
+
+1. **Implement** based on PRD requirements and reference S-expression format
+   - Update parser to extract new fields
+   - Update type definitions (dataclasses)
+   - Update formatter to emit fields in exact KiCAD format
+
+2. **Run tests** with verbose output and debug logging:
+   ```bash
+   # Run specific test file with debug logs
+   uv run pytest tests/unit/test_{feature}.py -v --log-cli-level=DEBUG
+
+   # Run reference tests
+   uv run pytest tests/reference_tests/test_{feature}_reference.py -v
+
+   # Run all related tests
+   uv run pytest tests/ -k "{feature}" -v
+   ```
+
+3. **Analyze logs and failures** (use debug logs from Step 4.1):
+   - What S-expression structure differs from reference?
+   - What fields are missing or incorrect?
+   - What values don't match expected format?
+   - Are there parsing errors or formatting issues?
+   - **Check debug logs** for parser/formatter decisions
+
+4. **Communicate progress** after each iteration:
+   > **Iteration {N}**:
+   > - Tests: {X} passing, {Y} failing (was {X-1} passing)
+   > - Issue found: {specific problem from logs}
+   > - Fix attempted: {what I'm trying - reference PRD Section X.Y}
+   > - Hypothesis: {why I think this will work}
+
+5. **Compare against reference schematic**:
+   ```bash
+   # Generate output from current implementation
+   python -c "
+   import kicad_sch_api as ksa
+   sch = ksa.Schematic.load('tests/reference_kicad_projects/{ref}/test.kicad_sch')
+   sch.save('/tmp/current_output.kicad_sch')
+   "
+
+   # Diff against reference (use logs to understand differences)
+   diff tests/reference_kicad_projects/{ref}/test.kicad_sch /tmp/current_output.kicad_sch
+   ```
+
+6. **Form hypothesis** about issue (based on logs and diff):
+   - "Missing field X in parser" (check parser debug logs)
+   - "Formatter emitting wrong order for fields" (check formatter debug logs)
+   - "UUID not being preserved in dataclass" (check data transformation logs)
+   - "Type conversion losing precision" (check type conversion logs)
+
+7. **Make targeted fix**:
+   - Update parser to extract missing field
+   - Reorder formatter output to match KiCAD
+   - Add field to dataclass
+   - Fix type conversion
+   - **Add more debug logging** if root cause unclear
+
+8. **Re-run tests** and validate improvement:
+   ```bash
+   uv run pytest tests/reference_tests/test_{feature}_reference.py -v --log-cli-level=DEBUG
+   ```
+
+**Progress indicators** (you're making progress if):
+- ✅ More tests pass than previous iteration
+- ✅ Diff shows fewer differences
+- ✅ S-expression structure closer to reference
+- ✅ Logs reveal new information about format
+
+**Stuck indicators** (escalate if):
+- ❌ Same failures after 3 iterations
+- ❌ No new information from logs or diffs
+- ❌ Tests pass but format doesn't match reference
+- ❌ Unclear which parser/formatter section to modify
+
+**Maximum iterations**: 8 attempts before asking for guidance
+
+**If stuck after 8 iterations**:
+> I've attempted 8 iterations but haven't resolved the issue yet. Here's what I've learned:
+>
+> **Current Status**:
+> - {N} tests passing, {M} tests failing
+> - Main issue: {specific problem}
+>
+> **S-expression Diff**:
+> ```
+> {Show key differences between output and reference}
+> ```
+>
+> **Hypotheses Tried**:
+> 1. {Hypothesis 1} - Result: {outcome}
+> 2. {Hypothesis 2} - Result: {outcome}
+>
+> **Stuck because**: {specific blocker}
+>
+> **Options**:
+> a) Try different approach: {alternative approach}
+> b) Need more information: {what information}
+> c) Simplify scope: {what to descope}
+>
+> Which would you like me to try?
+
+### Step 4.3: Format Preservation Validation
+
+**Once tests pass**, perform explicit format validation:
+
+```bash
+# Load and save reference schematic
+uv run python -c "
+import kicad_sch_api as ksa
+sch = ksa.Schematic.load('tests/reference_kicad_projects/{ref}/test.kicad_sch')
+sch.save('/tmp/format_validation.kicad_sch')
+"
+
+# Byte-perfect comparison
+diff tests/reference_kicad_projects/{ref}/test.kicad_sch /tmp/format_validation.kicad_sch
+
+# If byte-perfect fails, check semantic equivalence
+# (whitespace, field order differences acceptable for some elements)
+```
+
+**Validation criteria**:
+- ✅ **Byte-perfect**: Ideal - files are identical
+- ✅ **Semantic equivalence**: Acceptable - same meaning, minor formatting differences
+- ❌ **Missing fields**: Not acceptable - data loss
+- ❌ **Wrong values**: Not acceptable - incorrect output
+
+### Step 4.4: Implementation Complete Summary
+
+**When all tests pass and format preserved** (informational):
+> ✅ All tests passing:
+> - {N} unit tests ✅
+> - {M} reference tests ✅
+> - {K} integration tests ✅
+>
+> ✅ Format preservation validated:
+> - Byte-perfect match: {YES/NO}
+> - Semantic equivalence: {YES/NO}
+> - All required fields preserved: ✅
+>
+> **Diff Summary**:
+> ```
+> {Show diff output - should be minimal or empty}
+> ```
+>
+> Tests pass! Now proceeding to interactive manual validation...
+
+---
+
+## Phase 4.5: Interactive Manual Validation
+
+**Goal**: Prove the feature works through guided manual inspection in KiCAD
+
+This phase creates demo schematics and walks the user through step-by-step verification, proving the feature works before creating the PR.
+
+### Step 4.5.1: Plan Validation Scenario
+
+**Based on the feature**, determine what to demonstrate and help user think about manual tests.
+
+**For format preservation bugs** (e.g., pin UUIDs):
+- Create schematic with feature element
+- Show original values
+- Perform round-trip (load → save → load)
+- Compare values to prove preservation
+- **Manual test questions**: "What should I check in KiCAD to confirm this works? Should I verify the element is editable? Should I check properties panel?"
+
+**For new element support** (e.g., text boxes):
+- Create schematic with new element
+- Show it renders correctly in KiCAD
+- Verify all properties are accessible
+- Prove it can be modified
+- **Manual test questions**: "What visual checks guarantee this works? Can you edit it in KiCAD? Does it export correctly? Are there edge cases to try (empty text, special characters)?"
+
+**For API enhancements** (e.g., new methods):
+- Create schematic using new API
+- Show the result in KiCAD
+- Verify expected behavior
+- Test edge cases interactively
+- **Manual test questions**: "What scenarios prove this API works correctly? What would break if the implementation was wrong? What edge cases should we try?"
+
+**For connectivity/routing features**:
+- Create schematic with connections
+- Show connection data
+- Verify wires connect to correct pins visually
+- Compare netlist output
+- **Manual test questions**: "How can we confirm connectivity is correct? Should we compare netlist with kicad-cli? Should we check ERC in KiCAD?"
+
+**Prompt user to think about manual tests**:
+> Based on this feature, what manual checks would give you confidence it works correctly?
+>
+> Suggestions:
+> - {Suggestion 1 based on feature type}
+> - {Suggestion 2}
+> - {Suggestion 3}
+>
+> Any additional scenarios you want to test?
+
+### Step 4.5.2: Create Validation Script
+
+**Write a Python script** that demonstrates the feature:
+
+```python
+# Example: Pin UUID preservation validation
+import kicad_sch_api as ksa
+import json
+
+print("=" * 70)
+print("INTERACTIVE VALIDATION: {Feature Name}")
+print("=" * 70)
+
+# Step 1: Create demo schematic
+print("\n1️⃣ Creating demo schematic...")
+sch = ksa.create_schematic("validation_demo")
+# Add relevant elements for the feature
+component = sch.components.add(...)
+sch.save("/tmp/validation_demo.kicad_sch")
+print("✅ Saved to /tmp/validation_demo.kicad_sch")
+
+# Step 2: Extract baseline data
+print("\n2️⃣ Extracting baseline data...")
+# Read and display feature-specific data
+# Save baseline for comparison
+
+# Step 3: Prepare for user inspection
+print("\n" + "=" * 70)
+print("📋 BASELINE DATA:")
+print("-" * 70)
+# Display relevant data clearly
+print("-" * 70)
+```
+
+### Step 4.5.3: Guide User Through Validation
+
+**Open schematic and provide clear instructions**:
+
+```python
+# Open in KiCAD
+import subprocess
+subprocess.run(["open", "/tmp/validation_demo.kicad_sch"])
+
+print("\n" + "=" * 70)
+print("✋ WHAT YOU SHOULD SEE:")
+print("=" * 70)
+print("- {Specific element} at position {X, Y}")
+print("- {Property} should be {value}")
+print("- {Other observable characteristics}")
+
+print("\n✋ WHAT TO DO:")
+print("1. Look at {element} - verify it appears correctly")
+print("2. {Optional: inspect properties, modify something}")
+print("3. Close KiCAD (don't save changes)")
+print("4. Tell me 'closed' when ready to continue")
+print("=" * 70)
+```
+
+**Keep instructions simple**:
+- ✅ One schematic at a time
+- ✅ Clear bullet points for what to look for
+- ✅ Simple actions ("close KiCAD", "tell me closed")
+- ❌ Don't overwhelm with technical details
+- ❌ Don't ask user to verify code/UUIDs manually
+
+### Step 4.5.4: Run Validation Tests
+
+**After user inspects**, run automated validation:
+
+```python
+print("\n" + "=" * 70)
+print("🔄 VALIDATION TEST")
+print("=" * 70)
+
+# Perform feature-specific validation
+# Example: Round-trip test
+print("\n1️⃣ Loading original...")
+sch = ksa.Schematic.load("/tmp/validation_demo.kicad_sch")
+
+print("2️⃣ Performing {operation}...")
+# Do the operation that tests the feature
+sch.save("/tmp/validation_roundtrip.kicad_sch")
+
+print("3️⃣ Comparing results...")
+sch2 = ksa.Schematic.load("/tmp/validation_roundtrip.kicad_sch")
+
+# Compare relevant data
+all_passed = True
+print("\n📋 Comparison Results:")
+print("-" * 70)
+# Show clear pass/fail for each check
+if feature_data_matches:
+    print("✅ {Feature}: PRESERVED")
+else:
+    print("❌ {Feature}: CHANGED (BAD!)")
+    all_passed = False
+
+print("-" * 70)
+
+if all_passed:
+    print("\n🎉 SUCCESS: Feature is working correctly!")
+else:
+    print("\n❌ FAILURE: Feature has issues")
+```
+
+### Step 4.5.5: Show File-Level Proof
+
+**For format preservation features**, show byte-level comparison:
+
+```bash
+echo "📄 ORIGINAL FILE - {Feature} section:"
+echo "========================================================"
+grep -A 2 '{pattern}' /tmp/validation_demo.kicad_sch
+
+echo ""
+echo "📄 AFTER OPERATION - {Feature} section:"
+echo "========================================================"
+grep -A 2 '{pattern}' /tmp/validation_roundtrip.kicad_sch
+
+echo ""
+echo "🔍 CHECKING IF IDENTICAL:"
+echo "========================================================"
+if diff <(grep -A 2 '{pattern}' /tmp/validation_demo.kicad_sch) \
+        <(grep -A 2 '{pattern}' /tmp/validation_roundtrip.kicad_sch) > /dev/null 2>&1; then
+    echo "✅ IDENTICAL - Byte-perfect preservation!"
+else
+    echo "❌ DIFFERENT - Format changed"
+fi
+```
+
+### Step 4.5.6: Validation Examples by Feature Type
+
+**Format Preservation (e.g., pin UUIDs, properties)**:
+```
+1. Create schematic with element
+2. Show baseline values
+3. User inspects in KiCAD → closes
+4. Round-trip: load → save → load
+5. Compare values (should be identical)
+6. Show byte-level diff (should be empty)
+```
+
+**New Element Support (e.g., text boxes, shapes)**:
+```
+1. Create schematic with new element
+2. Show element properties
+3. User inspects in KiCAD → verifies rendering
+4. User optionally modifies in KiCAD → saves
+5. Load modified schematic
+6. Verify modifications were preserved
+```
+
+**API Enhancement (e.g., new methods)**:
+```
+1. Use new API to create schematic
+2. Show resulting structure
+3. User inspects in KiCAD → verifies result
+4. Try edge cases (empty values, special chars)
+5. Verify all cases work correctly
+```
+
+**Connectivity/Routing Features**:
+```
+1. Create schematic with connections
+2. Show connection data
+3. User inspects in KiCAD → verifies wires connect correctly
+4. Run netlist comparison vs kicad-cli
+5. Verify nets match exactly
+```
+
+### Step 4.5.7: Validation Checkpoint (USER APPROVAL REQUIRED)
+
+**Present validation summary and request approval**:
+> ✅ Interactive validation complete!
+>
+> **What we proved:**
+> 1. ✅ {Feature aspect 1} works correctly
+> 2. ✅ {Feature aspect 2} is preserved
+> 3. ✅ KiCAD opens and displays correctly
+> 4. ✅ {Format/behavior} matches expectations
+>
+> **Evidence:**
+> - Manual inspection: User confirmed {what}
+> - Automated tests: {N} checks passed
+> - File comparison: Byte-perfect match (if applicable)
+>
+> **Ready to proceed to cleanup and PR?**
+> - Type "yes" to proceed with cleanup and PR creation
+> - Type "no" or describe issues to go back to implementation
+
+**WAIT for user confirmation** before proceeding to Phase 5.
+
+**If user reports issues:**
+- Return to Phase 4 (Implementation)
+- Add more debug logging
+- Fix identified problems
+- Re-run Phase 4.5 validation
+
+---
+
+## Phase 5: Cleanup & Pull Request
+
+**Goal**: Production-ready code with documentation and PR
+
+### Step 5.1: Update Documentation
+
+**Update user-facing documentation** for the new feature:
+
+**README.md** - Add example to relevant section:
+```markdown
+### {Feature Category}
+
+```python
+# Example demonstrating new feature
+{code example}
+```
+
+**📖 See [API Reference](docs/API_REFERENCE.md#{feature-anchor}) for details**
+```
+
+**API_REFERENCE.md** - Add to appropriate section:
+```markdown
+#### {Feature Name}
+
+{Description of what this feature does}
+
+```python
+# Usage examples
+{comprehensive examples}
+```
+
+**Parameters:**
+- `param1` (type): Description
+- `param2` (type, optional): Description
+
+**Returns:** Return type and description
+
+**Notes:**
+- Important behavior
+- Edge cases
+- Format preservation details
+```
+
+**Documentation guidelines**:
+- ✅ Follow existing documentation structure
+- ✅ Use code examples (copy from validation phase)
+- ✅ Link between README and API_REFERENCE
+- ✅ Document all parameters and return types
+- ✅ Include notes about format preservation if relevant
+- ✅ Keep technical, avoid marketing language
+- ❌ Don't create new documentation files unless necessary
+- ❌ Don't document internal implementation details
+
+**Files to check**:
+- `README.md` - Main library documentation
+- `docs/API_REFERENCE.md` - Complete API documentation
+- `docs/RECIPES.md` - If adding a common pattern
+- `docs/GETTING_STARTED.md` - If affects getting started
+
+### Step 5.2: Code Cleanup
+
+**Remove debug logging**:
+```python
+# Comment out debug logs (preserve for future debugging)
+# logger.debug(f"Parsing {element_type}: {item}")  # DEBUG: Commented for cleanup
+
+# Keep production-level logging
+logger.warning(f"Unexpected element type: {element_type}")
+logger.error(f"Failed to parse {element}: {error}")
+```
+
+**Refactor if needed**:
+- Extract repeated code into helper functions
+- Improve variable names for clarity
+- Add production comments (explain WHY, not WHAT)
+- Simplify complex logic
+
+**Format code** (REQUIRED):
+```bash
+# Format with black
+uv run black kicad_sch_api/ tests/
+
+# Sort imports
+uv run isort kicad_sch_api/ tests/
+
+# Type checking
+uv run mypy kicad_sch_api/
+
+# Linting
+uv run flake8 kicad_sch_api/ tests/
+```
+
+### Step 5.3: Best Practices Review
+
+**Verify**:
+- [ ] Security (no hardcoded paths, validate inputs)
+- [ ] Error handling (all parse/format errors handled)
+- [ ] Type hints (all functions annotated)
+- [ ] All tests pass after cleanup
+- [ ] Public APIs have docstrings
+- [ ] S-expression format matches KiCAD exactly
+- [ ] Field ordering preserved
+- [ ] UUIDs preserved on round-trip
+- [ ] Grid alignment correct (if relevant)
+- [ ] Compatible with KiCAD 7.0 and 8.0
+- [ ] Backward compatibility maintained
+- [ ] MCP tools still work (if affected)
+
+### Step 5.4: Commit Message Format
+
+**Follow conventional commits** (from `CLAUDE.md`):
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+**Types**:
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation
+- `test`: Tests
+- `refactor`: Refactoring
+- `perf`: Performance
+- `chore`: Tooling, deps
+
+**Example**:
+```
+fix(parser): Preserve pin UUIDs during round-trip load/save
+
+Pin UUIDs were being dropped during schematic parsing because the
+Component dataclass didn't have a field to store them. This fix:
+
+- Adds pin_uuids field to SchematicSymbol dataclass
+- Updates symbol parser to extract pin UUIDs from S-expression
+- Updates formatter to emit pin entries with preserved UUIDs
+- Adds round-trip test to verify UUID preservation
+
+Fixes #139
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### Step 5.5: Pre-PR CI Validation and Fixing
+
+**CRITICAL**: Before creating a PR, ensure all CI checks will pass by running and fixing issues locally.
+
+**Run complete CI validation suite**:
+```bash
+# 1. Format code (FIX, don't just check)
+uv run black kicad_sch_api/ tests/
+uv run isort kicad_sch_api/ tests/
+
+# 2. Verify formatting is correct
+uv run black kicad_sch_api/ tests/ --check
+uv run isort kicad_sch_api/ tests/ --check
+
+# 3. Type checking
+uv run mypy kicad_sch_api/
+
+# 4. Linting
+uv run flake8 kicad_sch_api/ tests/
+
+# 5. All tests pass
+uv run pytest tests/ -v
+
+# 6. Format preservation tests
+uv run pytest tests/reference_tests/ -v -m format
+```
+
+**If any checks fail:**
+1. **Fix formatting issues** immediately with `black` and `isort`
+2. **Fix type errors** reported by `mypy`
+3. **Fix linting issues** reported by `flake8`
+4. **Fix failing tests** by returning to implementation phase
+5. **Re-run all checks** until everything passes
+
+**NEVER create a PR with failing CI** - fix all issues locally first.
+
+### Step 5.6: Create Pull Request
+
+**Final validation before PR**:
+```bash
+# Confirm all checks pass
+uv run black kicad_sch_api/ tests/ --check && \
+uv run isort kicad_sch_api/ tests/ --check && \
+uv run mypy kicad_sch_api/ && \
+uv run flake8 kicad_sch_api/ tests/ && \
+uv run pytest tests/ -v
+
+# If all pass, proceed with PR
+echo "✅ All checks passed - ready for PR"
+```
+
+**Generate PR description**:
+```markdown
+## Summary
+{1-2 sentence technical summary - NO marketing language}
+
+## Changes
+- {Change 1: specific file/module}
+- {Change 2: specific file/module}
+- {Change 3: specific file/module}
+
+## Testing
+- ✅ {N} unit tests (all passing)
+- ✅ {M} reference tests (all passing)
+- ✅ {K} integration tests (all passing)
+- ✅ Format preservation validated against reference schematic
+
+## Requirements Validated
+- [x] REQ-1: {requirement description}
+- [x] REQ-2: {requirement description}
+- [x] All acceptance criteria met
+
+## Format Preservation
+- Reference schematic: `tests/reference_kicad_projects/{ref}/`
+- Byte-perfect match: {YES/NO}
+- Semantic equivalence: {YES/NO}
+- KiCAD validation: Opens correctly in KiCAD {version}
+
+## Related
+- Closes #{issue number}
+- PRD: docs/prd/{feature-name}-prd.md
+- Reference: tests/reference_kicad_projects/{ref}/README.md
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+**Create PR**:
+```bash
+# Commit changes
+git add .
+git commit -m "{commit message following conventional commits format}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# Push and create PR
+git push origin HEAD
+gh pr create --title "{PR title}" --body "{PR description}"
+```
+
+### Step 5.7: PR Summary and Completion
+
+**Present completed PR**:
+> ✅ **Pull request created**: {PR URL}
+>
+> **Summary**:
+> - {N} tests added (all passing)
+> - {M} files changed
+> - All requirements validated
+> - Format preservation confirmed
+>
+> **Files Changed**:
+> - `kicad_sch_api/parsers/elements/{parser}.py` - Parser updates
+> - `kicad_sch_api/core/types.py` - Type definitions
+> - `tests/unit/test_{feature}.py` - Unit tests
+> - `tests/reference_tests/test_{feature}_reference.py` - Reference tests
+> - `tests/reference_kicad_projects/{ref}/` - Reference schematic
+> - `docs/prd/{feature}-prd.md` - PRD documentation
+>
+> **Development workflow complete!** PR is ready for review.
+
+---
+
+## Key Principles
+
+### Reference-Driven Development (TDD with KiCAD as Oracle)
+- **Reference = source of truth** - Human creates in KiCAD GUI (known-good)
+- **Tests compare against reference** - Agent knows when implementation succeeds
+- **Agent iterates autonomously** - Test pass = exact format match
+- **Parse reference to understand format** - S-expression becomes specification
+- **Replicate exact format in Python** - Byte-perfect or semantically equivalent output
+- **Keep references for regression testing** - Future validation and potential training data
+
+### Trusted Actions (Maximize Automation)
+- **Agent CAN automate**: `add_component()`, `add_wire()`, `add_label()`, basic connectivity
+- **Agent produces ugly but functional**: Complex routing, aesthetic positioning
+- **Human required**: Testing the APIs themselves, beautiful layouts, aesthetic judgment
+- **Decision rule**: If testing API behavior → agent creates reference. If testing aesthetics → human creates.
+- **Most common**: Agent creates functional reference, human optionally refines
+
+### Communicative Implementation
+- **Explain approach** before implementing (reference PRD sections)
+- **Show progress** after each iteration (tests passing, issues found, fixes tried)
+- **Reference PRD** when discussing requirements
+- **Human can interrupt** if agent going wrong direction
+- **Autonomous but transparent** - human follows along without blocking
+
+### KiCAD Format Preservation
+- **Exact S-expression matching** - Primary goal of the library
+- **Field order matters** - Preserve KiCAD's ordering
+- **UUID preservation critical** - Never generate new UUIDs for existing elements
+- **Grid alignment** - Positions must be grid-aligned (multiples of 1.27mm)
+
+### Strategic Logging (Python)
+- Use `logging` module, not `print()`
+- Debug logs during development, comment out before PR
+- Keep warning/error logs for production
+- Log at parse/format decision points
+- Logs drive hypothesis formation
+
+### Iterative Approach (Log-Driven)
+- Test → Analyze Logs → Fix → Repeat
+- Maximum 8 iterations before escalating
+- Progress = more tests passing or better format matching
+- Diff against reference constantly
+- Use debug logs to understand failures
+
+### Manual Validation (Belt-and-Suspenders)
+- **Always validate manually** even when tests pass
+- **Help user think** about what to check
+- **Guide step-by-step** - simple, clear instructions
+- **One schematic at a time** - respect human constraints
+- **Prove it works** before creating PR
+
+### Writing Guidelines (CRITICAL)
+- **NO marketing language** - follow `CLAUDE.md` banned words list
+- **Technical claims only** - "parses pin UUIDs" not "professional parsing"
+- **Engineer tone** - sharing a tool, not selling a product
+
+---
+
+## Output Artifacts
+
+At completion, you'll have:
+
+1. **PRD** (`docs/prd/{feature}-prd.md`)
+   - Technical requirements (no marketing language)
+   - KiCAD format specifications
+   - Success criteria
+
+2. **Reference Schematic** (`tests/reference_kicad_projects/{ref}/`)
+   - `test.kicad_sch` - KiCAD reference file
+   - `README.md` - Documentation of purpose and contents
+   - Source of truth for exact format
+
+3. **Test Suite** (`tests/`)
+   - Unit tests for functionality
+   - Reference tests for format preservation
+   - Integration tests if needed
+   - 100% requirement coverage
+
+4. **Implementation** (production code)
+   - Parser updates (`kicad_sch_api/parsers/`)
+   - Type definitions (`kicad_sch_api/core/types.py`)
+   - Formatter updates (`kicad_sch_api/parsers/`)
+   - All tests passing
+   - Format preservation validated
+
+5. **Pull Request**
+   - Conventional commit format
+   - Detailed description
+   - All quality checks passing
+   - Ready for review
+
+---
+
+## When to Use This Workflow
+
+| Use Case | Use `/dev` | Notes |
+|----------|-----------|-------|
+| Format preservation bug (e.g., #139) | ✅ Yes | Critical - use reference schematic to validate exact format |
+| New element support (e.g., #115, #117) | ✅ Yes | Create reference schematic manually, replicate in Python |
+| API enhancement (e.g., #142, #134) | ✅ Yes | Reference demonstrates desired behavior |
+| Round-trip testing (e.g., #141) | ✅ Yes | Multiple reference schematics for comprehensive testing |
+| Quick typo fix or docs update | ❌ No | Just fix directly, no need for full workflow |
+| Exploratory research | ❌ No | Use manual investigation first |
+
+---
+
+## Tips for Best Results
+
+**Good problem statements**:
+- ✅ "Pin UUIDs not preserved during round-trip load/save"
+- ✅ "Add support for text box elements with borders and margins"
+- ✅ "Add optional standard Y-axis coordinate system for easier API usage"
+
+**Poor problem statements**:
+- ❌ "Make it work" (what specifically?)
+- ❌ "Fix the parser" (which part?)
+- ❌ "Add stuff" (what stuff?)
+
+**Prepare for success**:
+- Be ready to edit schematic in KiCAD during Phase 2
+- Have KiCAD installed and ready to open files
+- Know which KiCAD elements are involved
+- Be available for checkpoint approvals (4 checkpoints)
+
+**Trust the process**:
+- **Don't skip phases** - each validates the previous
+- **Let iteration happen** - 8 attempts is reasonable for complex format issues
+- **Use checkpoints** - catch issues early
+- **Reference schematic is critical** - take time to create it properly
+
+**Naming is hard**:
+- Reference directory names will evolve
+- Include README.md in each reference directory
+- Document what the reference is for
+- Future: may reorganize for better discoverability
+
+---
+
+## Model Configuration
+
+**Default model**: Uses your configured default (typically `claude-sonnet-4-5`)
+- All phases use same model
+- Uses Claude Code subscription (free)
+- No API costs
+
+---
+
+**This is your complete development workflow for kicad-sch-api. Use it for systematic feature development with reference-driven testing and exact KiCAD format preservation.**

--- a/.claude/commands/dev/publish-pypi.md
+++ b/.claude/commands/dev/publish-pypi.md
@@ -1,0 +1,711 @@
+# PyPI Release Command - kicad-sch-api
+
+## Usage
+```bash
+/publish-pypi <version> [--test-only] [--check-only]
+```
+
+**⚠️ CRITICAL: Version number is MANDATORY - command will fail if not provided!**
+
+## Description
+Complete PyPI release pipeline - from testing to tagging to publishing. This command handles version management, git operations, comprehensive testing, and PyPI publication.
+
+## Parameters
+- `version` - **REQUIRED** Version number (e.g., "0.4.1", "1.0.0", "0.5.0-beta.1")
+- `--test-only`: Publish to Test PyPI only (for validation)
+- `--check-only`: Run all checks without publishing
+
+## What This Command Does
+
+This command automates the complete release process:
+
+### 1. Pre-Release Validation
+- **Check branch status** - Ensure we're on main branch
+- **Validate version format** - Semantic versioning check
+- **Check for uncommitted changes** - Ensure clean working directory
+- **Sync with remote** - Fetch latest changes from origin
+- **Version conflict check** - Ensure version doesn't already exist on PyPI or git tags
+
+### 2. Version Management
+- **Update pyproject.toml** - Set new version number
+- **Commit version changes** - Clean commit for version bump
+- **Show version comparison** - Display current vs new version
+
+### 3. Testing and Validation
+- **Run full test suite** - All tests must pass
+- **Code quality checks** - Black, isort, mypy, flake8
+- **Format preservation tests** - Critical for KiCAD compatibility
+- **Build package** - Create wheel and sdist
+- **Test installation** - Verify package installs correctly
+- **Import validation** - Ensure package imports work
+
+### 4. Git Operations
+- **Create release tag** - Tag commit with version number
+- **Push release tag** - Push tag to origin
+- **Create GitHub release** - Generate release notes and publish
+
+### 5. PyPI Publication
+- **Build distributions** - Create wheel and sdist
+- **Upload to PyPI** - Publish to registry
+- **Verify upload** - Check package is available
+
+### 6. Post-Release Verification
+- **Test installation from PyPI** - Verify package works
+- **Display release summary** - Show URLs and next steps
+
+## Implementation
+
+```bash
+#!/bin/bash
+set -e  # Exit on error
+
+# CRITICAL: Always require version number as parameter
+if [ -z "$1" ]; then
+    echo "❌ ERROR: Version number is required!"
+    echo "Usage: /publish-pypi <version> [--test-only] [--check-only]"
+    echo "Example: /publish-pypi 0.4.1"
+    echo "Example: /publish-pypi 0.5.0"
+    echo "Example: /publish-pypi 1.0.0-beta.1"
+    exit 1
+fi
+
+version="$1"
+shift  # Remove version from arguments
+
+# Parse flags
+TEST_ONLY=false
+CHECK_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --test-only)
+            TEST_ONLY=true
+            shift
+            ;;
+        --check-only)
+            CHECK_ONLY=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo "🎯 Starting release process for kicad-sch-api version: $version"
+echo "================================================================"
+
+# 1. Pre-flight checks and branch management
+echo "🔍 Running pre-flight checks..."
+
+# Fetch latest changes from remote
+echo "🔄 Fetching latest changes from origin..."
+git fetch origin
+
+# Ensure clean working directory
+if [ -n "$(git status --porcelain)" ]; then
+    echo "❌ Uncommitted changes found. Commit or stash first."
+    exit 1
+fi
+
+# Check current branch
+current_branch=$(git branch --show-current)
+if [[ "$current_branch" != "main" ]]; then
+    echo "⚠️  Warning: Not on main branch (currently on '$current_branch')"
+    read -p "Continue? (y/N): " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Validate version format (semantic versioning)
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+    echo "❌ Invalid version format. Use semantic versioning (e.g., 0.4.1, 1.0.0)"
+    echo "Provided: $version"
+    exit 1
+fi
+
+# Show current version for comparison
+current_version=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+echo "📊 Current version: $current_version"
+echo "📊 New version: $version"
+echo ""
+read -p "🤔 Confirm release version $version? (y/N): " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "❌ Release cancelled. Please specify the correct version."
+    exit 1
+fi
+
+# Check if version already exists on PyPI
+echo "🔍 Checking if version already exists on PyPI..."
+if pip index versions kicad-sch-api 2>/dev/null | grep -q "kicad-sch-api ($version)"; then
+    echo "❌ Version $version already exists on PyPI"
+    exit 1
+fi
+
+# Check if git tag already exists
+if git rev-parse "v$version" >/dev/null 2>&1; then
+    echo "❌ Git tag v$version already exists"
+    exit 1
+fi
+
+# Ensure main is up-to-date with origin
+echo "🔄 Ensuring main is up-to-date..."
+git pull origin main || {
+    echo "❌ Failed to pull latest main"
+    exit 1
+}
+
+# Install build dependencies
+echo "📥 Installing build dependencies..."
+uv pip install build twine --quiet
+
+# 2. Version update
+echo "📝 Updating version to $version..."
+
+# Update pyproject.toml
+sed -i.bak "s/^version = .*/version = \"$version\"/" pyproject.toml
+rm -f pyproject.toml.bak
+
+# Check if changes were made
+if ! git diff --quiet pyproject.toml; then
+    git add pyproject.toml
+    git commit -m "🔖 Bump version to $version"
+    echo "✅ Version updated and committed"
+else
+    echo "ℹ️  Version already up to date"
+fi
+
+# 3. Code quality checks
+echo "🎨 Checking code quality..."
+
+# Format check
+echo "  - Checking code formatting..."
+if ! uv run black --check kicad_sch_api/ tests/ --quiet 2>/dev/null; then
+    echo "❌ Code not formatted. Run: uv run black kicad_sch_api/ tests/"
+    exit 1
+fi
+
+# Import sort check
+echo "  - Checking import sorting..."
+if ! uv run isort --check-only kicad_sch_api/ tests/ --quiet 2>/dev/null; then
+    echo "❌ Imports not sorted. Run: uv run isort kicad_sch_api/ tests/"
+    exit 1
+fi
+
+# Type checking
+echo "  - Running type checks..."
+uv run mypy kicad_sch_api/ --ignore-missing-imports --quiet 2>/dev/null || {
+    echo "⚠️ Type checking issues found (non-blocking)"
+}
+
+echo "✅ Code quality checks passed"
+
+# 4. Comprehensive testing
+echo "🧪 Running comprehensive test suite..."
+
+# Core tests - format preservation is critical for KiCAD compatibility
+echo "  - Running unit tests..."
+if ! uv run pytest tests/ -v --tb=short -q; then
+    echo "❌ Tests failed"
+    exit 1
+fi
+
+# Format preservation tests (CRITICAL for KiCAD compatibility)
+echo "  - Running format preservation tests..."
+if ! uv run pytest tests/reference_tests/ -v --tb=short -q 2>/dev/null; then
+    echo "⚠️ Format preservation tests not found or failed"
+fi
+
+# Import validation
+echo "  - Testing imports..."
+if ! uv run python -c "import kicad_sch_api; print('✅ Import successful')" 2>/dev/null; then
+    echo "❌ Import test failed"
+    exit 1
+fi
+
+echo "✅ All tests passed"
+
+# 5. Build package
+echo "🏗️ Building package..."
+
+# Clean previous builds
+rm -rf build/ dist/ *.egg-info/ kicad_sch_api.egg-info/
+
+# Build
+if ! python -m build; then
+    echo "❌ Package build failed"
+    exit 1
+fi
+
+echo "✅ Package built successfully"
+
+# 6. Package validation
+echo "📋 Validating package..."
+
+# Check package integrity
+if ! twine check dist/*; then
+    echo "❌ Package validation failed"
+    exit 1
+fi
+
+# Test installation in clean environment
+echo "🧪 Testing package installation in isolated environment..."
+TEMP_VENV=$(mktemp -d)
+python -m venv "$TEMP_VENV"
+source "$TEMP_VENV/bin/activate"
+
+if ! pip install dist/*.whl --quiet; then
+    echo "❌ Package installation failed"
+    deactivate
+    rm -rf "$TEMP_VENV"
+    exit 1
+fi
+
+if ! python -c "import kicad_sch_api; print('✅ Package import successful')"; then
+    echo "❌ Package import failed"
+    deactivate
+    rm -rf "$TEMP_VENV"
+    exit 1
+fi
+
+deactivate
+rm -rf "$TEMP_VENV"
+
+echo "✅ Package validation complete"
+
+# 7. Exit if check-only
+if [[ "$CHECK_ONLY" == "true" ]]; then
+    echo ""
+    echo "================================================"
+    echo "✅ All pre-publication checks passed"
+    echo "================================================"
+    echo "📦 Package ready for publication"
+    echo "📊 Version: $version"
+    echo "🏷️  Next step: Run without --check-only to publish"
+    exit 0
+fi
+
+# 8. Git tagging and GitHub release
+echo "🏷️  Creating git tag and GitHub release..."
+
+# Verify we're on main branch for tagging
+current_branch_for_tag=$(git branch --show-current)
+if [[ "$current_branch_for_tag" != "main" ]]; then
+    echo "❌ Must be on main branch for release tagging"
+    echo "💡 Switch to main branch and re-run this command"
+    exit 1
+fi
+
+# Generate release notes from commits since last tag
+last_tag=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+if [ -n "$last_tag" ]; then
+    echo "📋 Generating release notes since $last_tag..."
+    release_notes=$(git log --pretty=format:"- %s (%h)" "$last_tag"..HEAD)
+else
+    echo "📋 Generating release notes for initial release..."
+    release_notes=$(git log --pretty=format:"- %s (%h)" --max-count=10)
+fi
+
+# Create git tag
+echo "🏷️  Creating git tag v$version..."
+git tag -a "v$version" -m "🚀 Release version $version
+
+Features and changes in this release:
+$release_notes
+
+Full changelog: https://github.com/circuit-synth/kicad-sch-api/compare/${last_tag}...v$version"
+
+# Push tag to origin
+echo "📤 Pushing release tag to origin..."
+git push origin "v$version" || {
+    echo "❌ Failed to push release tag"
+    exit 1
+}
+
+echo "✅ Tagged and pushed v$version"
+
+# Create GitHub release using gh CLI
+if command -v gh >/dev/null 2>&1; then
+    echo "📝 Creating GitHub release..."
+
+    gh release create "v$version" \
+        --title "🚀 Release v$version" \
+        --notes "## What's Changed
+
+$release_notes
+
+## Installation
+
+\`\`\`bash
+pip install kicad-sch-api==$version
+# or
+uv add kicad-sch-api==$version
+\`\`\`
+
+## PyPI Package
+📦 https://pypi.org/project/kicad-sch-api/$version/
+
+**Full Changelog**: https://github.com/circuit-synth/kicad-sch-api/compare/${last_tag}...v$version" \
+        --latest || {
+        echo "⚠️  GitHub release creation failed (continuing with PyPI release)"
+    }
+
+    echo "✅ GitHub release created"
+else
+    echo "⚠️  GitHub CLI (gh) not found - skipping GitHub release creation"
+    echo "💡 Install with: brew install gh"
+    echo "📝 Manual release notes:"
+    echo "$release_notes"
+fi
+
+# 9. Publish to PyPI
+echo ""
+echo "🚀 Publishing to PyPI..."
+
+if [[ "$TEST_ONLY" == "true" ]]; then
+    # Publish to Test PyPI
+    echo "📡 Publishing to Test PyPI..."
+
+    # Use environment variable or .pypirc
+    if [[ -n "$TEST_PYPI_API_TOKEN" ]]; then
+        twine upload --repository testpypi dist/* --username __token__ --password "$TEST_PYPI_API_TOKEN"
+    else
+        echo "ℹ️  Using .pypirc credentials for Test PyPI..."
+        twine upload --repository testpypi dist/*
+    fi
+
+    if [[ $? -eq 0 ]]; then
+        echo "✅ Successfully published to Test PyPI"
+        echo "🔗 View at: https://test.pypi.org/project/kicad-sch-api/"
+        echo "📥 Test install: pip install --index-url https://test.pypi.org/simple/ kicad-sch-api"
+    else
+        echo "❌ Test PyPI publication failed"
+        exit 1
+    fi
+
+else
+    # Publish to production PyPI
+    echo "📡 Publishing to Production PyPI..."
+
+    # Final confirmation
+    echo ""
+    echo "⚠️  WARNING: Publishing to PRODUCTION PyPI"
+    echo "This action cannot be undone for this version."
+    echo "Version: $version"
+    read -p "Continue? (y/N): " -n 1 -r confirm
+    echo ""
+
+    if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+        echo "❌ Publication cancelled"
+        # Clean up git tag since we're not publishing
+        git tag -d "v$version" 2>/dev/null
+        git push origin ":refs/tags/v$version" 2>/dev/null
+        exit 1
+    fi
+
+    # Use environment variable or .pypirc
+    if [[ -n "$PYPI_API_TOKEN" ]]; then
+        twine upload dist/* --username __token__ --password "$PYPI_API_TOKEN"
+    else
+        echo "ℹ️  Using .pypirc credentials for PyPI..."
+        twine upload dist/*
+    fi
+
+    if [[ $? -eq 0 ]]; then
+        echo ""
+        echo "🎉 Successfully published to PyPI!"
+        echo "🔗 View at: https://pypi.org/project/kicad-sch-api/$version/"
+        echo "📥 Install: pip install kicad-sch-api==$version"
+    else
+        echo "❌ PyPI publication failed"
+        exit 1
+    fi
+fi
+
+# 10. Post-release verification
+echo ""
+echo "⏳ Waiting for PyPI propagation (30 seconds)..."
+sleep 30
+
+# Verify package is available on PyPI
+echo "🔍 Verifying package on PyPI..."
+package_info=$(pip index versions kicad-sch-api 2>/dev/null || echo "not found")
+if [[ "$package_info" == *"$version"* ]]; then
+    echo "✅ Package verified on PyPI"
+else
+    echo "⚠️  Package not yet visible on PyPI (may take a few minutes)"
+fi
+
+# Test installation from PyPI in clean environment (production only)
+if [[ "$TEST_ONLY" == "false" ]]; then
+    echo "🧪 Testing installation from PyPI..."
+    temp_dir=$(mktemp -d)
+    cd "$temp_dir"
+    python -m venv test_env
+    source test_env/bin/activate
+
+    pip install kicad-sch-api==$version --quiet && \
+    python -c "import kicad_sch_api; print(f'✅ Installed version: {kicad_sch_api.__version__ if hasattr(kicad_sch_api, \"__version__\") else \"unknown\"}')" || \
+    echo "⚠️  Installation test from PyPI failed (package may still be propagating)"
+
+    deactivate
+    cd - >/dev/null
+    rm -rf "$temp_dir"
+fi
+
+# Final summary
+echo ""
+echo "================================================================"
+echo "🎉 Release v$version Complete!"
+echo "================================================================"
+echo "📊 Release Summary:"
+echo "   📦 PyPI: https://pypi.org/project/kicad-sch-api/$version/"
+echo "   🏷️  Git Tag: v$version"
+echo "   📋 GitHub: https://github.com/circuit-synth/kicad-sch-api/releases/tag/v$version"
+echo ""
+echo "✅ Publication process completed successfully"
+```
+
+## Usage Examples
+
+### Recommended Workflow
+
+```bash
+# 1. First, check that everything is ready (dry run)
+/publish-pypi 0.4.1 --check-only
+
+# 2. Test on Test PyPI first (HIGHLY RECOMMENDED)
+/publish-pypi 0.4.1 --test-only
+
+# 3. Verify Test PyPI installation works
+pip install --index-url https://test.pypi.org/simple/ kicad-sch-api==0.4.1
+
+# 4. If everything looks good, publish to production PyPI
+/publish-pypi 0.4.1
+```
+
+### Other Examples
+
+```bash
+# Release a patch version
+/publish-pypi 0.4.1
+
+# Release a minor version
+/publish-pypi 0.5.0
+
+# Release a major version
+/publish-pypi 1.0.0
+
+# Release a beta version
+/publish-pypi 1.0.0-beta.1
+
+# Release a release candidate
+/publish-pypi 1.0.0-rc.1
+```
+
+## Authentication Methods
+
+### Method 1: Environment Variables (Recommended for CI)
+
+#### For Test PyPI
+```bash
+export TEST_PYPI_API_TOKEN=pypi-your_test_token_here
+```
+
+#### For Production PyPI
+```bash
+export PYPI_API_TOKEN=pypi-your_production_token_here
+```
+
+### Method 2: .pypirc File (Recommended for Local Development)
+
+Create `~/.pypirc` with your API tokens:
+
+```ini
+[distutils]
+index-servers =
+    pypi
+    testpypi
+
+[pypi]
+repository = https://upload.pypi.org/legacy/
+username = __token__
+password = pypi-your_production_token_here
+
+[testpypi]
+repository = https://test.pypi.org/legacy/
+username = __token__
+password = pypi-your_test_token_here
+```
+
+**Using .pypirc:**
+```bash
+# Publish to Test PyPI using .pypirc
+twine upload --repository testpypi dist/*
+
+# Publish to Production PyPI using .pypirc  
+twine upload --repository pypi dist/*
+
+# Or use the default (production PyPI)
+twine upload dist/*
+```
+
+**Security Notes:**
+- Set proper file permissions: `chmod 600 ~/.pypirc`
+- Never commit `.pypirc` to version control
+- Environment variables take precedence over `.pypirc`
+- Use scoped API tokens (project-specific) instead of global tokens
+
+## Prerequisites
+
+Before running this command, ensure you have:
+
+1. **PyPI account** with API token configured
+2. **Git credentials** set up for pushing
+3. **GitHub CLI (gh)** installed and authenticated (for GitHub releases)
+4. **Clean working directory** (no uncommitted changes)
+5. **Main branch** checked out (for production releases)
+
+### Setup GitHub CLI
+```bash
+# Install GitHub CLI
+brew install gh
+
+# Authenticate with GitHub
+gh auth login
+
+# Verify authentication
+gh auth status
+```
+
+## Version Numbering Strategy
+
+This project follows **Semantic Versioning** (semver.org):
+
+- **MAJOR.MINOR.PATCH** (e.g., 0.4.1)
+- **MAJOR**: Breaking API changes
+- **MINOR**: New features, backward compatible
+- **PATCH**: Bug fixes, backward compatible
+
+**For pre-1.0 versions (0.x.y):**
+- Minor version bumps may include breaking changes
+- Communicate clearly in release notes
+- Move to v1.0.0 when API is stable
+
+**Examples:**
+- `0.4.0 → 0.4.1` - Bug fixes, small improvements
+- `0.4.1 → 0.5.0` - New features (bus support, netlist generation)
+- `0.5.0 → 1.0.0` - API stable, production ready
+
+## What Gets Released
+
+The release process creates:
+- **Python package** - Wheel and source distribution on PyPI
+- **Git tag** - Version tag on main branch (e.g., `v0.4.1`)
+- **GitHub release** - Auto-generated release notes
+- **Documentation** - All examples and docs included in package
+
+## Safety Features
+
+This enhanced command includes:
+
+✅ **Mandatory version parameter** - Prevents accidental releases
+✅ **Version conflict detection** - Checks PyPI and git tags
+✅ **Semantic versioning validation** - Ensures proper version format
+✅ **Clean working directory check** - No uncommitted changes
+✅ **Main branch enforcement** - Production releases only from main
+✅ **Comprehensive testing** - Unit tests, format preservation, imports
+✅ **Package validation** - Twine checks, installation tests
+✅ **Automatic git tagging** - Creates and pushes version tags
+✅ **GitHub release creation** - Auto-generated release notes
+✅ **Post-release verification** - Tests installation from PyPI
+
+## Troubleshooting
+
+### Common Issues
+
+**Version already exists:**
+```bash
+❌ Version 0.4.1 already exists on PyPI
+# Solution: Increment version number (you cannot overwrite PyPI versions)
+/publish-pypi 0.4.2
+```
+
+**Git tag already exists:**
+```bash
+❌ Git tag v0.4.1 already exists
+# Solution: Delete tag or use new version
+git tag -d v0.4.1  # Delete local tag
+git push origin :refs/tags/v0.4.1  # Delete remote tag
+```
+
+**Not on main branch:**
+```bash
+⚠️ Warning: Not on main branch (currently on 'develop')
+# Solution: Switch to main or force continue
+git checkout main
+git pull origin main
+```
+
+**Tests failing:**
+```bash
+❌ Tests failed
+# Solution: Fix failing tests before publishing
+uv run pytest tests/ -v
+```
+
+**GitHub CLI not found:**
+```bash
+⚠️ GitHub CLI (gh) not found - skipping GitHub release creation
+# Solution: Install gh (optional, not required for PyPI)
+brew install gh
+gh auth login
+```
+
+### Rollback Procedure
+
+If something goes wrong after publishing:
+
+```bash
+# 1. Yank the bad release from PyPI (prevents new installations)
+pip install twine
+twine yank kicad-sch-api --version BAD_VERSION
+
+# 2. Delete the git tag (optional)
+git tag -d vBAD_VERSION
+git push origin :refs/tags/vBAD_VERSION
+
+# 3. Delete the GitHub release (optional)
+gh release delete vBAD_VERSION
+
+# 4. Fix the issues and release a new patch version
+/publish-pypi NEW_VERSION
+```
+
+## Comparison with Previous Version
+
+### Old Command (Issue #2-4)
+❌ No version parameter
+❌ No git tagging
+❌ No GitHub releases
+❌ No version conflict detection
+❌ Manual version management
+
+### Enhanced Command (This Version)
+✅ Mandatory version parameter
+✅ Automatic git tagging
+✅ GitHub release creation
+✅ Version conflict detection
+✅ Automatic version updates
+✅ Comprehensive validation
+✅ Post-release verification
+
+This addresses **GitHub Issues #2, #3, and #4** by preventing version confusion and ensuring proper release workflow.
+
+---
+
+**This command provides a complete, automated PyPI release pipeline with comprehensive validation and safety checks, ensuring every release is properly tagged, tested, and documented.**

--- a/.claude/commands/dev/review-implementation.md
+++ b/.claude/commands/dev/review-implementation.md
@@ -1,0 +1,172 @@
+# Review Implementation Command - kicad-sch-api
+
+## Usage
+```bash
+/review-implementation [component]
+```
+
+## Description
+Performs comprehensive code review and analysis of kicad-sch-api implementation, focusing on professional quality, performance, and API design.
+
+## Parameters
+- `component` (optional): Specific component to review (`core`, `library`, `mcp`, `utils`, `tests`)
+- `--performance`: Focus on performance analysis
+- `--api-design`: Focus on API usability review
+- `--format-preservation`: Focus on format preservation validation
+
+## Review Areas
+
+### 1. Core Library Review
+```bash
+/review-implementation core
+```
+
+**Focuses on**:
+- **S-expression parsing** accuracy and performance
+- **Component management** API design and efficiency
+- **Schematic operations** completeness and validation
+- **Type system** correctness and usability
+- **Error handling** comprehensiveness and clarity
+
+**Key Questions**:
+- Does the API feel intuitive and pythonic?
+- Are bulk operations efficient for large schematics?
+- Is format preservation truly exact?
+- Do validation errors provide actionable feedback?
+
+### 2. Library Management Review
+```bash
+/review-implementation library
+```
+
+**Focuses on**:
+- **Symbol caching** performance and accuracy
+- **Library discovery** robustness across platforms
+- **Multi-source integration** (future: DigiKey, SnapEDA)
+- **Cache invalidation** and persistence
+
+**Key Questions**:
+- Does caching provide measurable performance improvement?
+- Is library discovery reliable across different KiCAD installations?
+- Are cache miss scenarios handled gracefully?
+
+### 3. MCP Integration Review
+```bash
+/review-implementation mcp
+```
+
+**Focuses on**:
+- **Tool completeness** for AI agent workflows
+- **Error handling** quality for agent consumption
+- **Python bridge** reliability and performance
+- **TypeScript integration** professional standards
+
+**Key Questions**:
+- Do MCP tools cover all essential schematic operations?
+- Are error messages clear enough for AI agents to understand?
+- Is the Python bridge robust against subprocess failures?
+
+### 4. Testing Strategy Review
+```bash
+/review-implementation tests
+```
+
+**Focuses on**:
+- **Test coverage** completeness and quality
+- **Reference schematics** representativeness
+- **Format preservation** validation accuracy
+- **Performance benchmarks** relevance
+
+**Key Questions**:
+- Do tests cover all critical functionality?
+- Are reference schematics representative of real-world usage?
+- Is format preservation testing comprehensive enough?
+
+## Review Checklist
+
+### API Design Quality
+- [ ] **Intuitive naming**: Method and property names are self-explanatory
+- [ ] **Consistent patterns**: Similar operations follow same patterns
+- [ ] **Type safety**: Proper type hints throughout
+- [ ] **Error messages**: Clear, actionable error descriptions
+- [ ] **Performance**: O(1) lookups, efficient bulk operations
+
+### Code Quality Standards
+- [ ] **Documentation**: All public methods have docstrings
+- [ ] **Logging**: Appropriate logging levels and messages
+- [ ] **Validation**: Input validation on all public methods
+- [ ] **Error handling**: Graceful degradation, no silent failures
+- [ ] **Memory efficiency**: No memory leaks, efficient data structures
+
+### Format Preservation
+- [ ] **Round-trip accuracy**: load → save → load produces identical results
+- [ ] **Whitespace preservation**: Indentation and spacing maintained
+- [ ] **Element ordering**: Order of elements preserved
+- [ ] **Quote consistency**: String quoting matches KiCAD conventions
+
+### Performance Benchmarks
+- [ ] **Symbol lookup**: <1ms for cached symbols
+- [ ] **Component operations**: <100ms for 1000 components
+- [ ] **File I/O**: <500ms for complex schematics
+- [ ] **Memory usage**: <100MB for large schematics
+
+### AI Agent Integration
+- [ ] **Tool completeness**: All essential operations available
+- [ ] **Error context**: Detailed error information for debugging
+- [ ] **Response format**: Consistent, structured responses
+- [ ] **Performance**: <1s response time for typical operations
+
+## Review Process
+
+### 1. Automated Analysis
+```bash
+# Code quality metrics
+uv run flake8 kicad_sch_api/ --statistics
+uv run mypy kicad_sch_api/ --show-error-codes
+
+# Test coverage
+uv run pytest tests/ --cov=kicad_sch_api --cov-report=term-missing
+
+# Performance profiling
+uv run python -m cProfile -s cumulative tests/test_performance.py
+```
+
+### 2. Manual Review Checklist
+- [ ] **API consistency** with established patterns
+- [ ] **Documentation completeness** for public methods
+- [ ] **Error handling** quality and coverage
+- [ ] **Performance characteristics** meet benchmarks
+- [ ] **Type annotations** accuracy and completeness
+
+### 3. Integration Validation
+- [ ] **MCP tools** work correctly with sample agents
+- [ ] **Format preservation** validated with real KiCAD files
+- [ ] **Library integration** discovers symbols correctly
+- [ ] **Bulk operations** perform efficiently
+
+## Professional Standards
+
+### Code Review Standards
+- **Readability**: Code should be self-documenting
+- **Maintainability**: Clear separation of concerns
+- **Testability**: Easy to unit test and mock
+- **Performance**: Optimized for real-world usage patterns
+- **Documentation**: Comprehensive API documentation
+
+### API Design Standards
+- **Intuitive**: Natural mental model for schematic operations
+- **Consistent**: Similar operations use similar patterns
+- **Powerful**: Supports both simple and complex operations
+- **Safe**: Validates inputs and prevents corruption
+- **Fast**: Optimized for large schematic workflows
+
+## Review Output
+
+The review generates:
+- **Quality metrics** and scores
+- **Performance benchmarks** vs. targets
+- **API usability** assessment
+- **Improvement recommendations** prioritized by impact
+- **Comparison analysis** vs. other schematic manipulation solutions
+
+This ensures kicad-sch-api maintains professional quality standards while providing superior functionality to existing solutions.

--- a/.claude/commands/dev/run-tests.md
+++ b/.claude/commands/dev/run-tests.md
@@ -1,0 +1,267 @@
+# Test Runner Command - kicad-sch-api
+
+## Usage
+```bash
+/run-tests [options]
+```
+
+## Description
+Orchestrates comprehensive testing for kicad-sch-api using uv and pytest, covering all functionality areas with professional test reporting.
+
+## Options
+- `--suite=standard` - Test suite: `quick`, `standard`, `full`, `coverage` (default: standard)
+- `--skip-install` - Skip dependency reinstallation (faster for development)
+- `--keep-outputs` - Don't delete generated test files
+- `--verbose` - Show detailed output
+- `--format=true` - Auto-format code before testing (default: true)
+- `--fail-fast=false` - Stop on first failure (default: false)
+
+## Test Suites
+
+### 🚀 Quick Suite (~10 seconds)
+Fast development testing:
+```bash
+uv run pytest tests/test_component_management.py tests/test_sexpr_parsing.py -q
+```
+
+### 📋 Standard Suite - Default (~30 seconds)
+Comprehensive core functionality:
+```bash
+# Auto-format if requested
+uv run black kicad_sch_api/ tests/ --quiet
+uv run isort kicad_sch_api/ tests/ --quiet
+
+# Run core tests
+uv run pytest tests/ -v --tb=short
+```
+
+### 🔬 Full Suite (~2 minutes)
+Complete validation including MCP server:
+```bash
+# Python library tests
+uv run pytest tests/ -v --cov=kicad_sch_api --cov-report=html
+
+# MCP server tests
+cd mcp-server && npm test
+
+# Format preservation tests
+uv run pytest tests/test_format_preservation.py -v
+
+# Reference schematic tests
+uv run pytest tests/reference_kicad_projects/ -v
+```
+
+### 📊 Coverage Suite (~1 minute)
+Detailed coverage analysis:
+```bash
+uv run pytest tests/ --cov=kicad_sch_api --cov-report=term-missing --cov-report=html --cov-fail-under=80
+```
+
+## Implementation
+
+```bash
+#!/bin/bash
+
+# Parse arguments
+SUITE="standard"
+SKIP_INSTALL=false
+KEEP_OUTPUTS=false
+VERBOSE=false
+FORMAT=true
+FAIL_FAST=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --suite=*)
+            SUITE="${1#*=}"
+            shift
+            ;;
+        --skip-install)
+            SKIP_INSTALL=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --format=*)
+            FORMAT="${1#*=}"
+            shift
+            ;;
+        --fail-fast)
+            FAIL_FAST=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Ensure we're in Python directory
+cd python || { echo "❌ Must run from kicad-sch-api root"; exit 1; }
+
+# Install dependencies if needed
+if [[ "$SKIP_INSTALL" == "false" ]]; then
+    echo "📦 Installing dependencies..."
+    uv pip install -e .[dev] --quiet
+fi
+
+# Pre-test formatting
+if [[ "$FORMAT" == "true" ]]; then
+    echo "🎨 Auto-formatting code..."
+    uv run black kicad_sch_api/ tests/ --quiet
+    uv run isort kicad_sch_api/ tests/ --quiet
+    echo "✅ Code formatted"
+fi
+
+# Build pytest arguments
+PYTEST_ARGS=""
+[[ "$VERBOSE" == "true" ]] && PYTEST_ARGS="$PYTEST_ARGS -v"
+[[ "$FAIL_FAST" == "true" ]] && PYTEST_ARGS="$PYTEST_ARGS -x"
+
+# Execute test suite
+case $SUITE in
+    quick)
+        echo "🚀 Running quick test suite..."
+        uv run pytest tests/test_component_management.py tests/test_sexpr_parsing.py -q $PYTEST_ARGS
+        ;;
+        
+    standard)
+        echo "📋 Running standard test suite..."
+        uv run pytest tests/ --tb=short $PYTEST_ARGS
+        ;;
+        
+    full)
+        echo "🔬 Running full test suite..."
+        
+        # Python library tests with coverage
+        uv run pytest tests/ --cov=kicad_sch_api --cov-report=term-missing $PYTEST_ARGS || exit 1
+        
+        # MCP server tests
+        if [[ -d "../mcp-server" ]]; then
+            echo "🤖 Testing MCP server..."
+            cd ../mcp-server
+            if [[ -f "package.json" ]]; then
+                npm test || echo "⚠️ MCP server tests failed"
+            fi
+            cd ../python
+        fi
+        
+        # Reference schematic tests
+        if [[ -d "tests/reference_kicad_projects" ]]; then
+            echo "📋 Testing reference schematics..."
+            uv run pytest tests/reference_kicad_projects/ -v $PYTEST_ARGS
+        fi
+        ;;
+        
+    coverage)
+        echo "📊 Running coverage analysis..."
+        uv run pytest tests/ --cov=kicad_sch_api --cov-report=term-missing --cov-report=html --cov-fail-under=70 $PYTEST_ARGS
+        echo "📊 Coverage report: htmlcov/index.html"
+        ;;
+        
+    *)
+        echo "❌ Unknown suite: $SUITE"
+        echo "Available suites: quick, standard, full, coverage"
+        exit 1
+        ;;
+esac
+
+# Cleanup if requested
+if [[ "$KEEP_OUTPUTS" == "false" ]]; then
+    echo "🧹 Cleaning up test outputs..."
+    rm -rf test_outputs/ .pytest_cache/ .coverage htmlcov/ 2>/dev/null || true
+fi
+
+echo "✅ Test suite completed"
+```
+
+## Expected Results by Suite
+
+**Quick Suite**:
+- ~5-10 tests, core functionality only
+- <10 seconds execution time
+- Good for rapid development iteration
+
+**Standard Suite**:
+- ~50-100 tests covering all core functionality
+- ~30 seconds execution time
+- Recommended for pre-commit validation
+
+**Full Suite**:
+- All tests + MCP server + reference schematics
+- ~2 minutes execution time
+- Recommended for pre-merge validation
+
+**Coverage Suite**:
+- Same as Standard but with detailed coverage analysis
+- Target: >80% code coverage
+- Generates HTML coverage report
+
+## Usage Examples
+
+```bash
+# Quick development check
+/run-tests --suite=quick
+
+# Standard pre-commit validation (default)
+/run-tests
+
+# Full validation before merge
+/run-tests --suite=full --verbose
+
+# Coverage analysis
+/run-tests --suite=coverage
+
+# Debug specific failures
+/run-tests --suite=standard --verbose --fail-fast
+
+# Fast iteration during debugging
+/run-tests --suite=quick --skip-install --format=false
+```
+
+## CI/CD Integration
+
+```yaml
+# GitHub Actions example
+- name: Quick Tests
+  run: /run-tests --suite=quick --fail-fast
+  
+- name: Full Tests (on PR)
+  run: /run-tests --suite=full
+  
+- name: Coverage Tests (on main)
+  run: /run-tests --suite=coverage
+```
+
+## Best Practices for kicad-sch-api
+
+1. **Development**: Use `--suite=quick` for rapid iteration
+2. **Pre-commit**: Run `--suite=standard` before committing
+3. **Pre-merge**: Run `--suite=full` before merging branches
+4. **Coverage analysis**: Use `--suite=coverage` to identify gaps
+5. **Debugging**: Use `--verbose --fail-fast` to isolate issues
+
+## kicad-sch-api Specific Testing
+
+### Core Functionality Tests
+- S-expression parsing and formatting
+- Component management and collections
+- Symbol library caching and performance
+- Validation and error handling
+
+### Integration Tests
+- Round-trip format preservation
+- Large schematic performance
+- MCP server functionality
+- Reference schematic parsing
+
+### Reference Schematic Coverage
+- Basic components (R, L, C, D)
+- Complex components (MCUs, connectors)
+- Hierarchical sheets and labels
+- Graphics and text elements
+
+This command provides a single entry point for all kicad-sch-api testing while maintaining the flexibility of specialized test tools.

--- a/.claude/commands/dev/update-and-commit.md
+++ b/.claude/commands/dev/update-and-commit.md
@@ -1,0 +1,201 @@
+# Update and Commit Command - kicad-sch-api
+
+## Usage
+```bash
+/update-and-commit "Brief description of changes"
+```
+
+## Description
+Comprehensive workflow for documenting progress, updating documentation, and committing changes to kicad-sch-api with professional quality standards.
+
+## Process
+
+### 1. Update Documentation (REQUIRED for Features)
+**IMPORTANT: Always update documentation BEFORE committing new features**
+- IF new user-facing features: Update README.md with examples
+- IF new API methods: Add to Advanced Features section in README.md
+- IF version increment needed: Update CHANGELOG.md with new version entry
+- IF new MCP tools: Update tool documentation
+- ALWAYS document new public methods with code examples
+- NO documentation changes needed for internal fixes or refactoring
+
+```bash
+# Documentation update checklist for new features:
+# 1. Add examples to README.md "Basic Usage" or "Advanced Features" sections
+# 2. Create CHANGELOG.md entry with version bump (patch/minor/major)
+# 3. Update any relevant example files in examples/
+# 4. Ensure CLAUDE.md reflects new functionality if developer-relevant
+```
+
+### 2. Format Code Before Committing
+**IMPORTANT: Always format code before committing**
+```bash
+# Format Python code
+uv run black kicad_sch_api/ tests/ --quiet
+uv run isort kicad_sch_api/ tests/ --quiet
+
+# Format TypeScript (MCP server)
+cd mcp-server && npm run format --silent 2>/dev/null || echo "TypeScript formatting skipped"
+cd ..
+
+# Format configuration files
+prettier --write "*.{json,yml,yaml}" --ignore-path .gitignore 2>/dev/null || echo "Config formatting skipped"
+```
+
+### 3. Quality Checks Before Committing
+**IMPORTANT: Run basic quality checks**
+```bash
+# Syntax validation
+find kicad_sch_api/ tests/ -name "*.py" -exec python -m py_compile {} \; 2>/dev/null || echo "⚠️ Syntax errors found"
+
+# Quick test run
+uv run pytest tests/test_component_management.py tests/test_sexpr_parsing.py -q || echo "⚠️ Core tests failing"
+
+# Import validation
+uv run python -c "import kicad_sch_api; print('✅ Import successful')" || echo "⚠️ Import failed"
+```
+
+### 4. Commit Changes (Selective and Clean)
+**IMPORTANT: Keep commit message under 3 lines**
+```bash
+# Check status and review changes
+git status
+
+# Add specific files (be selective) - ALWAYS include documentation if updated
+git add kicad_sch_api/ tests/ README.md CHANGELOG.md pyproject.toml
+
+# Remove unwanted files if any
+git rm unwanted-file.py 2>/dev/null || true
+
+# Commit with professional message
+git commit -m "Brief description of change
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+### 5. File Management Strategy
+**IMPORTANT: Be selective about what gets committed**
+
+```bash
+# 1. Review git status
+git status
+
+# 2. Handle different file categories:
+
+# Core library files - always include
+git add kicad_sch_api/
+
+# Tests - include if relevant
+git add tests/
+
+# Documentation - ALWAYS include if updated (REQUIRED for features)
+git add README.md CHANGELOG.md CLAUDE.md
+
+# Configuration - include if changed
+git add pyproject.toml pytest.ini
+
+# MCP server - include if relevant
+git add mcp-server/src/ mcp-server/package.json
+
+# Remove temporary files
+git rm '*.tmp' '*.log' 2>/dev/null || true
+git rm -r htmlcov/ .pytest_cache/ 2>/dev/null || true
+
+# 3. Final verification
+git status  # Should show only files you want to commit
+```
+
+### 6. kicad-sch-api Specific Checks
+
+```bash
+# Validate core functionality works
+uv run python -c "
+import kicad_sch_api as ksa
+sch = ksa.create_schematic('Test')
+comp = sch.components.add('Device:R', 'R1', '10k')
+print(f'✅ Core API working: {comp.reference} = {comp.value}')
+"
+
+# Check MCP server builds
+cd mcp-server && npm run build --silent && echo "✅ MCP server builds" || echo "⚠️ MCP build failed"
+cd ..
+
+# Validate package structure
+uv run python setup.py check --strict --metadata || echo "⚠️ Package metadata issues"
+```
+
+## Guidelines for kicad-sch-api
+
+- **Be concise**: Commit messages should focus on user impact
+- **Focus on features**: Document API improvements, new capabilities
+- **Skip internal changes**: Don't document refactoring unless it affects users
+- **Professional quality**: Ensure formatting and tests pass
+
+## Examples
+
+### Feature Addition
+```bash
+/update-and-commit "Add bulk component update operations for large schematics"
+```
+
+### Bug Fix
+```bash  
+/update-and-commit "Fix component reference validation for international characters"
+```
+
+### Performance Improvement
+```bash
+/update-and-commit "Optimize symbol caching for 10x faster library lookups"
+```
+
+### MCP Enhancement
+```bash
+/update-and-commit "Add hierarchical sheet MCP tools for AI agent workflows"
+```
+
+## File Categories for kicad-sch-api
+
+### Always Include
+- `kicad_sch_api/` - Core library code
+- `tests/` - Test files (when relevant)
+- `pyproject.toml` - Package configuration
+- `README.md` - User documentation (REQUIRED for new features)
+- `CHANGELOG.md` - Version history (REQUIRED for new features)
+
+### Include When Relevant
+- `mcp-server/` - MCP server changes
+- `CLAUDE.md` - Development guidance updates
+- `.claude/commands/` - Command updates
+- `examples/` - Usage examples
+
+### Never Include
+- `htmlcov/` - Coverage reports
+- `.pytest_cache/` - Test cache
+- `*.log` - Log files
+- `test_outputs/` - Temporary test files
+- `.venv/` - Virtual environment
+
+## Quality Standards
+
+Before committing, ensure:
+- ✅ **Tests pass**: At least quick suite runs successfully
+- ✅ **Code formatted**: Black and isort applied
+- ✅ **Imports work**: Basic import validation passes
+- ✅ **No syntax errors**: All Python files compile
+- ✅ **Clean git status**: Only intended files committed
+
+## Professional Commit Messages
+
+Good examples:
+- "Add exact format preservation for component properties"
+- "Implement high-performance symbol library caching"
+- "Add MCP tools for hierarchical sheet manipulation"
+
+Avoid:
+- "Fix stuff" or "Various improvements"
+- Technical implementation details
+- Long explanations of how changes work
+
+This command ensures professional quality commits while maintaining development velocity for kicad-sch-api.

--- a/.claude/commands/test/run-reference-tests.md
+++ b/.claude/commands/test/run-reference-tests.md
@@ -1,0 +1,303 @@
+# Reference Schematic Tests Command - kicad-sch-api
+
+## Usage
+```bash
+/run-reference-tests [project-name]
+```
+
+## Description
+Runs comprehensive tests against reference KiCAD schematic projects to validate parsing, manipulation, and format preservation across all schematic element types.
+
+## Parameters
+- `project-name` (optional): Specific reference project to test (e.g., "02_multiple_passive_components")
+- `--create-missing`: Create test files for reference projects that don't have tests yet
+- `--format-validation`: Focus on format preservation testing
+- `--performance`: Include performance benchmarking
+
+## Reference Project Structure
+
+```
+tests/reference_kicad_projects/
+├── README.md                           # Project checklist and status
+├── 01_simple_resistor/                 # ✅ Basic component
+│   ├── simple_resistor.kicad_sch
+│   └── test_simple_resistor.py
+├── 02_multiple_passive_components/     # 🔲 Component variety  
+│   ├── multiple_passives.kicad_sch
+│   └── test_multiple_passives.py
+├── 04_label_types/                     # 🔲 All label types
+│   ├── label_types.kicad_sch
+│   └── test_label_types.py
+└── [... 25 more reference projects]
+```
+
+## Implementation
+
+```bash
+#!/bin/bash
+
+# Parse arguments
+PROJECT_NAME=""
+CREATE_MISSING=false
+FORMAT_VALIDATION=false
+PERFORMANCE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --create-missing)
+            CREATE_MISSING=true
+            shift
+            ;;
+        --format-validation)
+            FORMAT_VALIDATION=true
+            shift
+            ;;
+        --performance)
+            PERFORMANCE=true
+            shift
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+        *)
+            PROJECT_NAME="$1"
+            shift
+            ;;
+    esac
+done
+
+# Ensure we're in correct directory
+cd python/tests/reference_kicad_projects || {
+    echo "❌ Must run from kicad-sch-api root"
+    exit 1
+}
+
+if [[ -n "$PROJECT_NAME" ]]; then
+    # Test specific project
+    if [[ ! -d "$PROJECT_NAME" ]]; then
+        echo "❌ Reference project not found: $PROJECT_NAME"
+        echo "Available projects:"
+        ls -1 | grep -E '^[0-9]+_' | head -10
+        exit 1
+    fi
+    
+    echo "🧪 Testing reference project: $PROJECT_NAME"
+    
+    # Run project-specific tests
+    if [[ -f "$PROJECT_NAME/test_${PROJECT_NAME}.py" ]]; then
+        cd ../../..  # Back to python directory
+        uv run pytest "tests/reference_kicad_projects/$PROJECT_NAME/" -v
+    else
+        echo "⚠️ No test file found for $PROJECT_NAME"
+        if [[ "$CREATE_MISSING" == "true" ]]; then
+            echo "🔧 Creating test template..."
+            # Create test template (implementation below)
+        fi
+    fi
+else
+    # Test all reference projects
+    echo "🧪 Testing all reference schematic projects..."
+    
+    cd ../../..  # Back to python directory
+    
+    # Run all reference tests
+    if [[ "$FORMAT_VALIDATION" == "true" ]]; then
+        uv run pytest tests/reference_kicad_projects/ -v -k "format_preservation"
+    elif [[ "$PERFORMANCE" == "true" ]]; then
+        uv run pytest tests/reference_kicad_projects/ -v -k "performance"
+    else
+        uv run pytest tests/reference_kicad_projects/ -v
+    fi
+fi
+```
+
+## Test Template Generation
+
+When `--create-missing` is used, generates test template:
+
+```python
+# Template: test_{project_name}.py
+"""
+Tests for {project_name} reference schematic.
+Tests parsing, manipulation, and format preservation.
+"""
+
+import pytest
+from pathlib import Path
+
+from kicad_sch_api.core.schematic import Schematic
+from kicad_sch_api.utils.validation import ValidationError
+
+
+class Test{ProjectName}:
+    """Test {project_name} reference schematic functionality."""
+
+    @pytest.fixture
+    def reference_schematic_path(self):
+        """Get path to reference schematic."""
+        return Path(__file__).parent / "{project_name}.kicad_sch"
+
+    @pytest.fixture
+    def loaded_schematic(self, reference_schematic_path):
+        """Load reference schematic for testing."""
+        return Schematic.load(reference_schematic_path)
+
+    def test_parse_{project_name}(self, loaded_schematic):
+        """Test parsing {project_name} without errors."""
+        # Basic parsing validation
+        assert loaded_schematic is not None
+        assert loaded_schematic.version is not None
+        assert loaded_schematic.uuid is not None
+        
+        # Validate component count matches expectations
+        # TODO: Update expected count based on actual schematic
+        expected_components = 1  # Update this
+        assert len(loaded_schematic.components) == expected_components
+
+    def test_round_trip_format_preservation(self, reference_schematic_path, tmp_path):
+        """Test that format is preserved in round-trip operations."""
+        # Load original
+        sch = Schematic.load(reference_schematic_path)
+        
+        # Save to temporary file
+        output_path = tmp_path / "output.kicad_sch"
+        sch.save(output_path, preserve_format=True)
+        
+        # Read both files
+        with open(reference_schematic_path, 'r') as f:
+            original = f.read()
+        with open(output_path, 'r') as f:
+            output = f.read()
+        
+        # Validate structural preservation
+        assert original.count('(symbol') == output.count('(symbol')
+        assert original.count('(property') == output.count('(property')
+        
+        # TODO: Add specific element validation based on project content
+
+    def test_modify_{project_name}(self, loaded_schematic, tmp_path):
+        """Test modifying {project_name} elements."""
+        # Make a simple modification
+        if len(loaded_schematic.components) > 0:
+            first_comp = loaded_schematic.components[0]
+            original_value = first_comp.value
+            first_comp.value = "modified_value"
+            
+            # Save and reload
+            output_path = tmp_path / "modified.kicad_sch"
+            loaded_schematic.save(output_path)
+            
+            sch2 = Schematic.load(output_path)
+            modified_comp = sch2.components.get(first_comp.reference)
+            
+            assert modified_comp.value == "modified_value"
+            assert modified_comp.value != original_value
+
+    def test_validation_{project_name}(self, loaded_schematic):
+        """Test validation of {project_name}."""
+        issues = loaded_schematic.validate()
+        
+        # Should have no critical errors
+        errors = [issue for issue in issues if issue.level.value in ('error', 'critical')]
+        assert len(errors) == 0, f"Validation errors found: {[str(e) for e in errors]}"
+```
+
+## Test Execution Examples
+
+```bash
+# Test all reference projects
+/run-reference-tests
+
+# Test specific project
+/run-reference-tests 02_multiple_passive_components
+
+# Test with format validation focus
+/run-reference-tests --format-validation
+
+# Test with performance benchmarking
+/run-reference-tests --performance
+
+# Create missing test files
+/run-reference-tests --create-missing
+
+# Test specific category
+/run-reference-tests 04_label_types --format-validation
+```
+
+## Expected Coverage by Project
+
+### Basic Components (Projects 01-03)
+- **Parse accuracy**: All components extracted correctly
+- **Property handling**: Values, footprints, custom properties
+- **Position accuracy**: Coordinate preservation
+- **Reference validation**: Unique references maintained
+
+### Labels and Text (Projects 04-05)
+- **Label types**: Local, global, hierarchical parsing
+- **Text elements**: Text boxes, annotations, special characters
+- **Font effects**: Size, bold, italic, justification
+- **Unicode handling**: International characters preserved
+
+### Hierarchical Design (Projects 06-10)
+- **Sheet symbols**: Hierarchical sheet parsing
+- **Pin mapping**: Hierarchical pin connections
+- **Multi-file projects**: Cross-file reference resolution
+- **Deep nesting**: Complex hierarchy validation
+
+### Complex Components (Projects 11-16)
+- **Symbol inheritance**: "extends" relationship handling
+- **Multi-unit symbols**: Unit numbering and shared properties
+- **Large pin counts**: 100+ pin components (MCUs, FPGAs)
+- **Special component types**: Power symbols, connectors
+
+### Graphics and Advanced (Projects 17-28)
+- **Graphical elements**: Shapes, lines, arcs
+- **Images**: Embedded graphics and logos
+- **Performance**: Large schematic handling
+- **Edge cases**: Format limits and unusual elements
+
+## Quality Metrics
+
+### Performance Targets
+- **Parsing time**: <100ms for typical schematics
+- **Memory usage**: <50MB for complex schematics  
+- **Symbol lookup**: <1ms for cached symbols
+- **Bulk operations**: <10ms per component update
+
+### Accuracy Targets
+- **Format preservation**: 100% byte-level accuracy for unchanged elements
+- **Round-trip fidelity**: 100% data preservation
+- **Validation coverage**: All schematic rules validated
+- **Error detection**: All format violations caught
+
+## Integration with CI/CD
+
+```yaml
+# GitHub Actions integration
+- name: Reference Schematic Tests
+  run: |
+    cd python
+    /run-reference-tests --format-validation
+
+- name: Performance Benchmarks
+  run: |
+    cd python  
+    /run-reference-tests --performance
+```
+
+## Troubleshooting
+
+**If reference tests fail**:
+1. Check that reference schematic files are valid KiCAD format
+2. Verify kicad-sch-api installation: `uv run python -c "import kicad_sch_api"`
+3. Run single test for debugging: `uv run pytest tests/reference_kicad_projects/01_simple_resistor/ -v -s`
+4. Check test logs for specific parsing errors
+
+**If format preservation fails**:
+1. Enable debug logging to see parsing details
+2. Compare original vs. output files manually
+3. Check for whitespace or encoding differences
+4. Validate S-expression structure integrity
+
+This command ensures all reference schematics work correctly with kicad-sch-api and maintain professional quality standards.

--- a/.claude/commands/user/create-schematic.md
+++ b/.claude/commands/user/create-schematic.md
@@ -1,0 +1,195 @@
+---
+name: create-schematic
+description: Create a KiCAD schematic from a description
+---
+
+# Create Schematic Command
+
+Generate a complete KiCAD schematic file from a natural language description using kicad-sch-api.
+
+## Usage
+
+```bash
+/create-schematic <description>
+```
+
+## Examples
+
+```bash
+# Simple circuit
+/create-schematic "voltage divider with two 10k resistors"
+
+# Power supply
+/create-schematic "3.3V voltage regulator circuit with AMS1117 and bypass capacitors"
+
+# LED circuit
+/create-schematic "LED circuit with 330 ohm resistor and 5V power supply"
+
+# More complex
+/create-schematic "ESP32-C3 dev board with USB-C, voltage regulator, and reset button"
+```
+
+## What This Does
+
+This command:
+1. Analyzes your circuit description
+2. Selects appropriate components from KiCAD libraries
+3. Creates schematic with proper component placement
+4. Adds pin-to-pin wiring connections
+5. Sets component properties (values, footprints, etc.)
+6. Saves to a .kicad_sch file in current directory
+7. Provides summary of components used
+
+## Implementation
+
+When you provide a circuit description, I will:
+
+### 1. Parse Requirements
+- Identify required components (resistors, capacitors, ICs, etc.)
+- Determine component values from description
+- Identify connections and topology
+
+### 2. Select Components
+```python
+# Select appropriate KiCAD library components
+# Device:R for resistors
+# Device:C for capacitors
+# Device:LED for LEDs
+# Regulator_Linear:AMS1117-3.3 for voltage regulators
+# RF_Module:ESP32-C3-MINI-1 for ESP32
+# etc.
+```
+
+### 3. Generate Schematic
+```python
+import kicad_sch_api as ksa
+
+# Create schematic with descriptive title
+sch = ksa.create_schematic("Circuit Name from Description")
+
+# Add components with proper spacing
+# Position components logically (left to right: input -> processing -> output)
+# Add appropriate footprints for each component
+
+# Wire components together
+# Use pin-to-pin wiring for automatic routing
+# Add power symbols and ground connections
+
+# Add labels for important nets
+# Set component properties (tolerance, power rating, etc.)
+
+# Save to file
+sch.save("circuit_name.kicad_sch")
+```
+
+### 4. Best Practices Applied
+
+**Component Placement:**
+- Input on left, output on right
+- Power supplies at top
+- Ground at bottom
+- Logical signal flow
+
+**Component Selection:**
+- Standard KiCAD footprints (0603, 0805 for passives)
+- Common ICs with proper package types
+- Connectors with correct pinouts
+
+**Properties:**
+- Footprints assigned to all components
+- Values set appropriately
+- Power ratings on resistors
+- Voltage ratings on capacitors
+- Part numbers for ICs
+
+**Wiring:**
+- Clean orthogonal routing
+- Proper net labels
+- Power symbols where appropriate
+
+## Output
+
+After running, you'll get:
+1. **Schematic file**: `circuit_name.kicad_sch` in current directory
+2. **Component summary**: List of all components added
+3. **Next steps**: How to open in KiCAD and proceed
+
+## Example Session
+
+```
+User: /create-schematic "LED with 330 ohm current limiting resistor for 5V"
+
+Claude: I'll create an LED circuit with current limiting resistor for you.
+
+[Creates schematic with]
+- LED (Device:LED)
+- Resistor 330Ω (Device:R)
+- Power connector
+- Ground connection
+- Proper footprints and wiring
+
+✅ Schematic saved: led_circuit.kicad_sch
+
+Components used:
+- D1: LED (LED_SMD:LED_0603_1608Metric)
+- R1: 330Ω resistor (Resistor_SMD:R_0603_1608Metric)
+- J1: Power connector (Connector:Conn_01x02)
+
+Next steps:
+1. Open in KiCAD: kicad led_circuit.kicad_sch
+2. Review and adjust component placement
+3. Add PCB layout
+```
+
+## Tips
+
+**Be Specific**: The more details you provide, the better the result.
+- "3.3V regulator" → Will use common LDO like AMS1117
+- "Buck converter 5V to 3.3V" → Will use switching regulator topology
+- "ESP32 dev board" → Will include USB, voltage regulator, buttons, etc.
+
+**Common Components Recognized:**
+- Resistors, capacitors, inductors, LEDs
+- Voltage regulators (linear and switching)
+- Microcontrollers (ESP32, STM32, ATmega, etc.)
+- Op-amps, comparators
+- USB connectors, headers
+- Buttons, switches
+
+**Circuit Patterns:**
+- Voltage dividers
+- RC filters (low-pass, high-pass)
+- LED drivers
+- Power supplies
+- Decoupling networks
+- Pull-up/pull-down resistors
+
+## Hierarchical Schematics
+
+For complex designs with multiple subsystems, I can create hierarchical schematics:
+
+```bash
+/create-schematic "STM32 development board with separate sheets for power, MCU, USB, and peripherals"
+```
+
+**This will create:**
+- Main schematic with hierarchical sheet symbols
+- Separate schematic files for each subsystem
+- Proper hierarchical connections using sheet pins
+
+**Important**: When creating hierarchical schematics, the code automatically uses `set_hierarchy_context()` to ensure component references display correctly in KiCad.
+
+See `examples/stm32g431_simple.py` for a complete hierarchical design example.
+
+## Limitations
+
+- Cannot design analog circuits requiring specific tuning
+- Cannot optimize for specific performance requirements automatically
+- Generated schematics may need manual refinement
+- Complex ICs may need manual pin assignment review
+
+## See Also
+
+- Check `examples/complete_board_example.py` for complex board template
+- See `llm.txt` for complete API documentation
+- Read `examples/README.md` for learning progression

--- a/.claude/commands/user/generate-circuit.md
+++ b/.claude/commands/user/generate-circuit.md
@@ -1,0 +1,549 @@
+---
+name: generate-circuit
+description: Expert guidance on using kicad-sch-api Python library to generate KiCAD schematics with CRUD operations for all schematic components (add, list, update, remove components, wires, labels, junctions)
+---
+
+# Generate Professional KiCAD Circuit Schematic
+
+You are generating a professional KiCAD schematic using `kicad-sch-api` with expert-level component placement and routing.
+
+## User's Circuit Request
+
+**Description:** {{arg}}
+
+Your task is to generate a complete, professional Python script that creates this circuit schematically.
+
+---
+
+## ⚠️ ULTRA CRITICAL: GRID ALIGNMENT (1.27mm) ⚠️
+
+**🔴 THE MOST CRITICAL RULE: ALL POSITIONS MUST BE ON 1.27mm GRID! 🔴**
+
+**KiCAD uses a 1.27mm (50 mil) grid for schematic components and wires.**
+
+**EVERY position MUST be a multiple of 1.27mm:**
+- ✅ Valid: 0, 1.27, 2.54, 3.81, 5.08, 6.35, 7.62, 8.89, 10.16, 11.43, 12.70...
+- ✅ Valid: 100.33, 101.60, 102.87, 104.14, 105.41, 106.68, 107.95...
+- ❌ Invalid: 100.5, 115.3, 129.540, 184.150 (OFF GRID!)
+
+**Why this matters:**
+- Off-grid components cause **crooked wires**
+- Off-grid wires cause **connectivity issues**
+- Off-grid placement looks **unprofessional**
+- Can cause **ERC (Electrical Rule Check) failures**
+
+**How to ensure grid alignment:**
+
+```python
+def snap_to_grid(value, grid=1.27):
+    """Snap a value to nearest grid point."""
+    return round(value / grid) * grid
+
+# Use for ALL positions
+signal_y = snap_to_grid(130.0)  # Ensures exactly on grid
+r1_x = snap_to_grid(180.0)
+vout_x = snap_to_grid(200.0)
+
+# Verify grid alignment
+assert signal_y % 1.27 < 0.01, f"Y position {signal_y} not on 1.27mm grid!"
+```
+
+**Pin positions and grid:**
+- Component centers MUST be on grid
+- Pin offsets from component center may cause pins to be off-grid
+- **Use actual pin positions from `list_component_pins()` for wire endpoints** (already on correct positions)
+- **Never manually calculate pin positions** - always query them!
+
+---
+
+## ⚠️ CRITICAL: KiCAD Y-Axis Is INVERTED ⚠️
+
+**THE SECOND MOST IMPORTANT THING TO UNDERSTAND:**
+
+**In KiCAD schematics, the Y-axis is INVERTED compared to normal math coordinates:**
+- **LOWER Y values = HIGHER on screen (TOP of schematic)**
+- **HIGHER Y values = LOWER on screen (BOTTOM of schematic)**
+- **X-axis is normal** (increases to the right)
+
+**This means:**
+- Power symbol at TOP of schematic → **SMALL Y value** (e.g., Y = 100mm)
+- Ground symbol at BOTTOM of schematic → **LARGE Y value** (e.g., Y = 160mm)
+- Component above another → **SMALLER Y value**
+- Wire going DOWN → **INCREASING Y values**
+
+**If your circuit appears upside-down (GND at top, +5V at bottom), you have the Y-axis backwards!**
+
+---
+
+## Core Placement Principles
+
+### 1. Visual Layout Conventions
+
+**Vertical Layout:**
+- **Power at TOP** (small Y values) - +5V, +3V3, VCC symbols
+- **Ground at BOTTOM** (large Y values) - GND symbols
+- Creates natural top-to-bottom reading direction
+
+**Horizontal Layout:**
+- **Input on LEFT** - Signal sources start on left
+- **Output on RIGHT** - Signal destinations on right
+
+**Component Orientation:**
+- **Vertical components** for top-to-bottom connections (resistors, LEDs)
+- **Polarized components** oriented for readability:
+  - LED cathodes point toward ground (downward)
+  - Capacitor negative toward ground
+  - Diode cathode (bar) toward load/ground
+
+**⚠️ CRITICAL ALIGNMENT RULE:**
+- **Vertical circuits**: All components in a stack MUST have the **SAME X coordinate**
+- **Horizontal circuits**: All components in a chain MUST have the **SAME Y coordinate**
+- **If you see diagonal wires, your component placement is WRONG!**
+
+---
+
+### 2. Horizontal Signal Flow Circuits (CRITICAL!)
+
+**For left-to-right signal paths (filters, amplifiers, signal chains):**
+
+**🔴 CRITICAL: Use `add_with_pin_at()` for perfect horizontal alignment!**
+
+**🎉 NEW API (v0.6.0+): Pin-Aligned Placement - Eliminates Manual Calculations!**
+
+The library now provides `add_with_pin_at()` which places components by specifying WHERE A SPECIFIC PIN should be, rather than where the component center should be. This **eliminates all manual pin offset calculations and verification loops!**
+
+```python
+# SIMPLE: Connection PINS must be at signal_y
+signal_y = rect_center_y  # Choose one Y coordinate for entire signal path
+
+# NEW WAY: Direct pin positioning (RECOMMENDED!)
+# Place resistor with output pin (pin 2) on signal line
+r1 = sch.components.add_with_pin_at(
+    lib_id='Device:R',
+    pin_number='2',  # Which pin to position
+    pin_position=(r1_x, signal_y),  # Where that pin should be
+    value='1k',
+    reference='R1'
+)
+
+# Place capacitor with input pin (pin 1) on signal line
+c1 = sch.components.add_with_pin_at(
+    lib_id='Device:C',
+    pin_number='1',  # Which pin to position
+    pin_position=(c1_x, signal_y),  # Where that pin should be
+    value='100nF',
+    reference='C1'
+)
+
+# ✅ GUARANTEED: R1 pin 2 and C1 pin 1 are now EXACTLY at signal_y!
+# ✅ NO verification needed - alignment is automatic!
+# ✅ Works with ANY rotation!
+
+# Ground BELOW the signal path
+gnd_y = signal_y + 30  # 30mm below signal line
+gnd = sch.components.add('power:GND', '#PWR01', value='GND', position=(c1_x, gnd_y))
+```
+
+**Benefits of `add_with_pin_at()`:**
+- ✅ **No manual pin offset calculations** - just specify where the pin should be
+- ✅ **No verification loops needed** - alignment is guaranteed
+- ✅ **Code is 66% shorter** - clean and readable
+- ✅ **Works with any rotation** - handles transformations automatically
+- ✅ **Intent is clear** - code says exactly what it does
+
+**Alternative: Align existing components**
+
+If you already have components placed, use `align_pin()` to fix alignment:
+
+```python
+# Component already exists but not aligned
+r1 = sch.components.get('R1')
+
+# Move it so pin 2 is at the signal line
+r1.align_pin('2', (r1_x, signal_y))
+```
+
+**Common mistakes (OLD WAY):**
+- ❌ Manual calculation: "capacitor pin 1 at Y=96.19, so center at Y=103.81"
+- ❌ Verification loops checking if pins are on signal line
+- ❌ Remove/recreate cycle when alignment is wrong
+
+**Rule:** Horizontal signal flow = Use `add_with_pin_at()` with CONNECTION PINS at same Y coordinate!
+
+**Why this matters:**
+- Before: 30+ lines of complex verification and repositioning code
+- After: 3 lines per component with guaranteed alignment
+- Result: Cleaner code, fewer bugs, faster development
+
+---
+
+### 3. Circuit Centering Strategy (CRITICAL!)
+
+**Always calculate rectangle center FIRST, then work backwards:**
+
+```python
+# 1. Define desired rectangle location and size
+rect_x1 = 140
+rect_y1 = 90
+rect_x2 = 240
+rect_y2 = 170
+
+# 2. Calculate rectangle center
+rect_center_x = (rect_x1 + rect_x2) / 2  # 190
+rect_center_y = (rect_y1 + rect_y2) / 2  # 130
+
+# 3. Calculate circuit dimensions (how much space it needs)
+branch_spacing = 50  # Distance between left and right branches
+circuit_height = 60  # Distance from top power to bottom GND
+
+# 4. Calculate starting position to CENTER the circuit
+base_x = rect_center_x - (branch_spacing / 2)  # 190 - 25 = 165
+base_y = rect_center_y - (circuit_height / 2)  # 130 - 30 = 100
+
+# 5. Now place components relative to base position
+left_x = base_x              # 165 (left branch)
+right_x = base_x + branch_spacing  # 215 (right branch)
+power_y = base_y             # 100 (TOP - small Y!)
+resistor_y = base_y + 20
+led_y = base_y + 40
+gnd_y = base_y + 60          # 160 (BOTTOM - large Y!)
+
+# 6. VERIFY CENTERING (important check!)
+circuit_actual_center_x = (left_x + right_x) / 2  # Should equal rect_center_x
+circuit_actual_center_y = (power_y + gnd_y) / 2   # Should equal rect_center_y
+assert abs(circuit_actual_center_x - rect_center_x) < 1.0, "Circuit not centered horizontally!"
+assert abs(circuit_actual_center_y - rect_center_y) < 1.0, "Circuit not centered vertically!"
+```
+
+---
+
+### 3. Component Spacing Guidelines
+
+**Horizontal spacing between parallel branches:**
+- Use **40-60mm** between branches (50mm is ideal)
+- NOT 80mm+ (too sparse)
+
+**Vertical spacing between components:**
+- **15-20mm** between component centers
+- Power to resistor: 20mm
+- Resistor to LED: 20mm
+- LED to ground: 20mm
+
+**Total dimensions:**
+- Circuit width (2 branches): **100-130mm**
+- Circuit height (4 stages): **70-85mm**
+
+---
+
+### 4. Component Rotation and Pin Verification (CRITICAL!)
+
+**⚠️ WARNING: After rotating components, ALWAYS verify pin positions!**
+
+Different components behave differently with rotation. Pin locations change based on rotation angle.
+
+**CRITICAL: Resistor Rotation in KiCAD**
+
+Resistor orientation is counter-intuitive:
+- **`rotation=0`**: Vertical resistor (pins top/bottom)
+- **`rotation=90`**: Horizontal resistor (pins left/right) ← Use this for horizontal signal paths!
+
+**When rotation changes, pin order MAY change - ALWAYS query actual positions!**
+
+**Best practice workflow for horizontal components:**
+
+```python
+# 1. Place component with rotation for horizontal orientation
+r1 = sch.components.add('Device:R', 'R1', '1k', position=(r_x, signal_y), rotation=90)
+
+# 2. Query ACTUAL pin positions (returns Point objects)
+r_pins = sch.list_component_pins('R1')
+r_pin1_pos = r_pins[0][1]  # Point object with .x and .y
+r_pin2_pos = r_pins[1][1]  # Point object with .x and .y
+
+# 3. CRITICAL: Determine left/right based on actual X coordinates (NOT pin numbers!)
+if r_pin1_pos.x < r_pin2_pos.x:
+    r_left_pin = r_pin1_pos
+    r_right_pin = r_pin2_pos
+else:
+    r_left_pin = r_pin2_pos
+    r_right_pin = r_pin1_pos
+
+# 4. Wire based on actual positions (prevents crossed wires!)
+sch.add_wire(start=(in_x, signal_y), end=r_left_pin)
+sch.add_wire(start=r_right_pin, end=(out_x, signal_y))
+```
+
+**Common rotation issues:**
+- ❌ Assuming pin 1 is always left after rotation (WRONG - it depends on rotation!)
+- ❌ Using rotation=0 for horizontal resistors (creates vertical resistor)
+- ❌ Not querying actual pin positions → crossed wires over component body
+
+**LED Rotation Guide (vertical orientation with cathode pointing DOWN):**
+
+```python
+# CORRECT - cathode points down (toward higher Y)
+d1 = sch.components.add(
+    'Device:LED',
+    reference='D1',
+    value='GREEN',
+    position=(x, y),
+    rotation=270  # 90° CCW from 0° - cathode points DOWN
+)
+```
+
+**LED rotation guide:**
+- `rotation=0`: Cathode points RIGHT (horizontal)
+- `rotation=90`: Cathode points UP (WRONG for vertical)
+- `rotation=180`: Cathode points LEFT (horizontal)
+- `rotation=270`: **Cathode points DOWN (CORRECT for vertical circuits)**
+
+**Rule:** Don't assume pin positions after rotation. Always query with `list_component_pins()` and determine left/right by X coordinate!
+
+---
+
+### 5. Power Symbol Values (CRITICAL!)
+
+**Power symbols MUST have voltage as value, NOT reference:**
+
+```python
+# CORRECT - shows "+3V3" in schematic
+pwr = sch.components.add('power:+3V3', reference='#PWR01', value='+3V3')
+
+# CORRECT - shows "+5V" in schematic
+pwr = sch.components.add('power:+5V', reference='#PWR02', value='+5V')
+
+# CORRECT - shows "GND" in schematic
+gnd = sch.components.add('power:GND', reference='#PWR03', value='GND')
+
+# WRONG - creates BLANK symbol
+pwr = sch.components.add('power:+3V3', reference='#PWR01', value='#PWR01')  # ❌
+```
+
+**Rule:**
+- Reference: Always `#PWRxx` format (e.g., #PWR01, #PWR02)
+- **Value: MUST be the voltage string** (e.g., '+3V3', '+5V', 'GND')
+
+---
+
+### 6. Wire Routing with list_component_pins() (CRITICAL!)
+
+**ALWAYS use `list_component_pins()` for accurate wire connections:**
+
+```python
+# list_component_pins returns: [(pin_number, (x, y)), ...]
+r1_pins = sch.list_component_pins("R1")
+d1_pins = sch.list_component_pins("D1")
+
+# r1_pins = [('1', (165.0, 116.19)), ('2', (165.0, 123.81))]
+# d1_pins = [('1', (165.0, 136.19)), ('2', (165.0, 143.81))]
+
+# Get pin positions (tuples, not dicts!)
+r1_pin2_pos = r1_pins[1][1]  # [1]=second pin, [1]=position tuple
+d1_pin1_pos = d1_pins[0][1]  # [0]=first pin, [1]=position tuple
+
+# Wire them together with exact pin positions
+sch.add_wire(start=r1_pin2_pos, end=d1_pin1_pos)
+```
+
+**Benefits:**
+- ✅ No guessing pin offsets
+- ✅ Accounts for component rotation automatically
+- ✅ Works for any component type
+- ✅ Exact positions, no gaps
+
+**WRONG approach:**
+```python
+# Don't guess offsets!
+sch.add_wire(start=(x, y - 1.905), end=(x, y + 1.905))  # ❌
+```
+
+---
+
+### 7. Text Positioning (CRITICAL!)
+
+**Title (above rectangle):**
+```python
+title_y = rect_y1 - 10  # Above rectangle top
+title_x = rect_center_x  # Centered
+
+sch.add_text(
+    "CIRCUIT TITLE",
+    position=(title_x, title_y),
+    size=2.0  # Larger than annotations
+)
+```
+
+**Annotation (INSIDE rectangle bottom):**
+```python
+# CRITICAL: annotation_y MUST be < rect_y2 (inside rectangle)
+annotation_y = rect_y2 - 10  # 10mm from bottom, safely INSIDE
+annotation_x = rect_center_x  # Centered
+
+sch.add_text(
+    "Circuit description",
+    position=(annotation_x, annotation_y),
+    size=1.27  # Standard KiCAD size
+)
+
+# VERIFY: annotation_y < rect_y2
+assert annotation_y < rect_y2, "Text outside rectangle!"
+```
+
+**Text length limits:**
+- Single line: **max 50 characters**
+- Use abbreviations (L/R instead of Left/Right)
+- Split into multiple lines if needed
+
+---
+
+### 8. Label Connection Requirements (CRITICAL!)
+
+**⚠️ Labels MUST be placed AT wire endpoints, not near them!**
+
+```python
+# WRONG - label offset from wire (floating label, not connected!)
+wire_start = (160, 115)
+sch.add_wire(start=wire_start, end=(180, 115))
+sch.add_label("Vin", position=(150, 115))  # ❌ Offset by 10mm - NOT CONNECTED!
+
+# CORRECT - label exactly at wire endpoint (connected!)
+wire_start = (160, 115)
+sch.add_wire(start=wire_start, end=(180, 115))
+sch.add_label("Vin", position=wire_start)  # ✅ At wire endpoint - CONNECTED!
+```
+
+**Rule for signal labels:**
+1. Place wire first
+2. Save wire endpoint coordinates
+3. Place label at EXACT same coordinates as wire endpoint
+4. Verify label touches the wire visually
+
+**Common mistake:** Offsetting labels for "readability" creates floating labels that aren't electrically connected
+
+**Exception:** Component value/reference labels can be offset (handled automatically)
+
+---
+
+### 9. Junction Placement
+
+**Junctions required at ALL T-junction points (3+ wires meeting):**
+
+```python
+# Add junction at power rail branch point
+sch.junctions.add(position=(x, power_y))
+```
+
+**Rule:** Junction position must be EXACTLY at wire intersection
+
+---
+
+### 10. Rectangle Placement
+
+**Add rectangle with exact bounds:**
+
+```python
+sch.add_rectangle(start=(rect_x1, rect_y1), end=(rect_x2, rect_y2))
+```
+
+---
+
+## Verification Checklist
+
+Before generating the final script, mentally verify:
+
+- [ ] **🔴 GRID ALIGNMENT**: ALL positions are multiples of 1.27mm (use snap_to_grid function!)
+- [ ] **Y-axis correct**: Power at small Y (TOP), GND at large Y (BOTTOM)
+- [ ] **Circuit centered**: Calculations verified, center matches rectangle center
+- [ ] **🎉 NEW: Use `add_with_pin_at()`**: For horizontal signal flows - eliminates manual alignment!
+- [ ] **Component alignment**: Same X for vertical, same Y for horizontal (NO DIAGONALS!)
+- [ ] **LED rotation**: `rotation=270` for vertical circuits (cathode down)
+- [ ] **Power symbol values**: Voltage strings ('+3V3', '+5V', 'GND'), not references
+- [ ] **Wire routing**: All wires use `list_component_pins()` tuples (pins already grid-aligned)
+- [ ] **Labels connected**: Labels at exact wire endpoints, not offset
+- [ ] **Text inside bounds**: `annotation_y < rect_y2`
+- [ ] **Spacing balanced**: 40-60mm horizontal, 15-20mm vertical
+- [ ] **Junctions added**: At all T-connection points
+
+---
+
+## Output Requirements
+
+Generate a complete Python script that:
+
+1. **Imports kicad-sch-api**: `import kicad_sch_api as ksa`
+2. **Creates schematic**: `sch = ksa.create_schematic("Circuit Name")`
+3. **Uses exact centering calculations** as shown above
+4. **Adds all components** with proper positions and rotations
+5. **Routes all wires** using `list_component_pins()`
+6. **Adds junctions** at T-connections
+7. **Adds text** (title above, annotation inside bottom)
+8. **Adds rectangle** with calculated bounds
+9. **Saves schematic**: `sch.save('output_name.kicad_sch')`
+10. **Includes verification** assertions for centering
+11. **Adds helpful comments** explaining positioning calculations
+
+**Script should be complete, executable, and generate a professional schematic on first run.**
+
+---
+
+## Example Template Structure
+
+```python
+#!/usr/bin/env python3
+"""
+[Circuit Description]
+"""
+
+import kicad_sch_api as ksa
+
+# Create schematic
+sch = ksa.create_schematic("Circuit Name")
+
+# Rectangle bounds and centering calculations
+# Default: center circuit around (100, 100) for upper-left placement
+rect_x1, rect_y1 = 50, 50
+rect_x2, rect_y2 = 150, 150
+rect_center_x = (rect_x1 + rect_x2) / 2  # 100
+rect_center_y = (rect_y1 + rect_y2) / 2  # 100
+
+# Circuit dimensions
+branch_spacing = 50
+circuit_height = 60
+
+# Base position (centered)
+base_x = rect_center_x - (branch_spacing / 2)
+base_y = rect_center_y - (circuit_height / 2)
+
+# Component positions
+# ... (calculate all positions)
+
+# Add components
+# ... (use proper API calls)
+
+# Get pin positions
+# ... (use list_component_pins)
+
+# Wire connections
+# ... (use pin positions)
+
+# Add junctions
+# ... (at T-connections)
+
+# Add text
+# ... (title above, annotation inside)
+
+# Add rectangle
+sch.add_rectangle(start=(rect_x1, rect_y1), end=(rect_x2, rect_y2))
+
+# Verify centering
+# ... (assertions)
+
+# Save
+sch.save('output.kicad_sch')
+
+print("Circuit created successfully!")
+```
+
+---
+
+**Now generate the complete Python script for the user's circuit request!**

--- a/.claude/commands/user/troubleshoot-library.md
+++ b/.claude/commands/user/troubleshoot-library.md
@@ -1,0 +1,172 @@
+---
+name: troubleshoot-library
+description: Troubleshoot KiCAD symbol library path discovery issues
+---
+
+# Troubleshoot KiCAD Symbol Library Issues
+
+## Common Symptom
+
+User reports errors like:
+- "Library not found"
+- "Symbol X:Y not found"
+- "Cannot load component from library"
+- Components fail to create with library errors
+
+## Root Cause
+
+The kicad-sch-api library cannot find KiCAD symbol libraries (`.kicad_sym` files).
+
+## Solution: Configure Library Paths
+
+### Step 1: Find Your KiCAD Installation
+
+**✨ NEW: Automatic Library Finder**
+
+The easiest way to find your KiCAD libraries:
+
+```bash
+ksa-find-libraries
+```
+
+This command automatically searches your system and provides setup instructions.
+
+**Manual Search (if needed):**
+
+**macOS:**
+```bash
+ls /Applications/KiCad*.app/Contents/SharedSupport/symbols/
+```
+
+**Linux:**
+```bash
+ls /usr/share/kicad/symbols/
+ls ~/.local/share/kicad/*/symbols/
+```
+
+**Windows:**
+```powershell
+dir "C:\Program Files\KiCad\*\share\kicad\symbols"
+```
+
+### Step 2: Set Environment Variable
+
+**macOS/Linux:**
+```bash
+# Generic (works for any version)
+export KICAD_SYMBOL_DIR=/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols
+
+# Version-specific (if you have KiCAD 8)
+export KICAD8_SYMBOL_DIR=/Applications/KiCad806/KiCad.app/Contents/SharedSupport/symbols/
+
+# Add to ~/.bashrc or ~/.zshrc to make permanent
+echo 'export KICAD8_SYMBOL_DIR=/Applications/KiCad806/KiCad.app/Contents/SharedSupport/symbols/' >> ~/.zshrc
+```
+
+**Windows PowerShell:**
+```powershell
+$env:KICAD8_SYMBOL_DIR="C:\Program Files\KiCad\8.0\share\kicad\symbols"
+
+# Make permanent:
+[System.Environment]::SetEnvironmentVariable('KICAD8_SYMBOL_DIR', 'C:\Program Files\KiCad\8.0\share\kicad\symbols', 'User')
+```
+
+### Step 3: Verify Configuration
+
+Create a test script:
+
+```python
+#!/usr/bin/env python3
+import kicad_sch_api as ksa
+
+# Test library discovery
+cache = ksa.SymbolLibraryCache(enable_persistence=False)
+lib_count = cache.discover_libraries()
+
+print(f"Discovered {lib_count} libraries")
+
+# Test loading a symbol
+symbol = cache.get_symbol("Device:R")
+if symbol:
+    print("✓ Successfully loaded Device:R")
+else:
+    print("✗ Failed to load symbol")
+```
+
+Run with:
+```bash
+python test_library.py
+```
+
+## Supported Environment Variables
+
+The library checks these environment variables in order:
+
+1. `KICAD_SYMBOL_DIR` - Generic, works for any KiCAD version
+2. `KICAD9_SYMBOL_DIR` - KiCAD 9 specific
+3. `KICAD8_SYMBOL_DIR` - KiCAD 8 specific
+4. `KICAD7_SYMBOL_DIR` - KiCAD 7 specific
+
+You can specify multiple paths separated by:
+- `:` on macOS/Linux
+- `;` on Windows
+
+Example:
+```bash
+export KICAD_SYMBOL_DIR=/path/1:/path/2:/custom/symbols
+```
+
+## Alternative: Programmatic Configuration
+
+If environment variables aren't an option:
+
+```python
+import kicad_sch_api as ksa
+
+# Add custom library path
+cache = ksa.SymbolLibraryCache()
+cache.add_library_path("/path/to/kicad/symbols")
+cache.discover_libraries()
+
+# Now create schematic
+sch = ksa.create_schematic("MyCircuit")
+```
+
+## Verification
+
+Check library discovery worked:
+
+```python
+import kicad_sch_api as ksa
+
+cache = ksa.SymbolLibraryCache(enable_persistence=False)
+count = cache.discover_libraries()
+
+if count > 0:
+    print(f"✓ Found {count} libraries")
+
+    # Test common symbols
+    for lib_id in ["Device:R", "Device:C", "power:GND"]:
+        symbol = cache.get_symbol(lib_id)
+        if symbol:
+            print(f"  ✓ {lib_id}")
+        else:
+            print(f"  ✗ {lib_id} not found")
+else:
+    print("✗ No libraries found - check environment variables")
+```
+
+## Documentation
+
+For complete details, see:
+- `docs/LIBRARY_CONFIGURATION.md`
+- README section on "Library Path Configuration"
+
+## When to Use This Command
+
+Use this troubleshooting guide when:
+- User reports "library not found" errors
+- Component creation fails with symbol errors
+- User is on non-standard KiCAD installation
+- User needs custom library paths
+- Library discovery returns 0 libraries

--- a/.claude/hooks/context_bundle_builder.py
+++ b/.claude/hooks/context_bundle_builder.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+"""
+Context Bundle Builder - Claude Code Hook (JSONL version)
+Tracks files accessed (Read/Write) and user prompts during a Claude Code session
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def handle_file_operations(input_data: dict) -> None:
+    """Handle Read/Write tool operations."""
+    # Extract relevant data
+    session_id = input_data.get("session_id", "unknown")
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    tool_response = input_data.get("tool_response", {})
+    
+    # Only process Read and Write tools
+    if tool_name not in ["Read", "Write"]:
+        sys.exit(0)
+    
+    # Extract file path
+    file_path = tool_input.get("file_path")
+    if not file_path:
+        sys.exit(0)
+    
+    # Check if Write operation was successful
+    if tool_name == "Write" and tool_response:
+        success = tool_response.get("success", True)
+        if not success:
+            sys.exit(0)
+    
+    # Convert absolute path to relative
+    try:
+        # Use CLAUDE_PROJECT_DIR if available, otherwise use cwd
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+        abs_path = Path(file_path).resolve()
+        project_path = Path(project_dir).resolve()
+        
+        # Try to make path relative to project directory
+        try:
+            relative_path = abs_path.relative_to(project_path)
+            file_path_relative = str(relative_path)
+        except ValueError:
+            # If file is outside project directory, keep absolute path
+            file_path_relative = file_path
+    except Exception:
+        # If any error, keep original path
+        file_path_relative = file_path
+    
+    # Create the log entry
+    log_entry = {
+        "operation": tool_name.lower(),  # "read" or "write"
+        "file_path": file_path_relative
+    }
+    
+    # Add tool_input parameters (excluding file_path since we already have it)
+    tool_input_filtered = {}
+    if tool_name == "Read":
+        if "limit" in tool_input:
+            tool_input_filtered["limit"] = tool_input["limit"]
+        if "offset" in tool_input:
+            tool_input_filtered["offset"] = tool_input["offset"]
+    elif tool_name == "Write":
+        # For Write, we might want to track content length but not the content itself
+        if "content" in tool_input:
+            tool_input_filtered["content_length"] = len(tool_input.get("content", ""))
+    
+    # Only add tool_input if there are parameters to save
+    if tool_input_filtered:
+        log_entry["tool_input"] = tool_input_filtered
+    
+    # Write to JSONL file
+    write_log_entry(session_id, log_entry)
+
+
+def handle_user_prompt(input_data: dict) -> None:
+    """Handle UserPromptSubmit events."""
+    # Extract relevant data
+    session_id = input_data.get("session_id", "unknown")
+    prompt = input_data.get("prompt", "")
+    
+    if not prompt:
+        sys.exit(0)
+    
+    # Create minimal log entry for prompt
+    log_entry = {
+        "operation": "prompt",
+        "prompt": prompt[:500]  # Limit prompt length to avoid huge logs
+    }
+    
+    # Write to JSONL file
+    write_log_entry(session_id, log_entry)
+
+
+def write_log_entry(session_id: str, log_entry: dict) -> None:
+    """Write a log entry to the JSONL file."""
+    # Generate filename with day_hour and session_id
+    now = datetime.now()
+    day_hour = now.strftime("%a_%H").upper()
+    
+    # Create directory structure
+    bundle_dir = Path("agents/context_bundles")
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Use JSONL file (JSON Lines format)
+    bundle_file = bundle_dir / f"{day_hour}_{session_id}.jsonl"
+    
+    # Append to JSONL file (atomic operation for small writes)
+    try:
+        with open(bundle_file, 'a') as f:
+            # Write as a single line of JSON
+            f.write(json.dumps(log_entry) + '\n')
+    except IOError as e:
+        print(f"Error appending to context bundle: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Context Bundle Builder")
+    parser.add_argument("--type", choices=["file_ops", "user_prompt"], 
+                       default="file_ops",
+                       help="Type of operation to handle")
+    args = parser.parse_args()
+    
+    try:
+        # Read hook input from stdin
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Route to appropriate handler
+    if args.type == "file_ops":
+        handle_file_operations(input_data)
+    elif args.type == "user_prompt":
+        handle_user_prompt(input_data)
+    
+    # Success - exit silently
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/dangerous_command_blocker.py
+++ b/.claude/hooks/dangerous_command_blocker.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+"""
+Dangerous Command Blocker - Claude Code Hook
+Prevents execution of dangerous commands like rm -rf
+"""
+
+import json
+import re
+import sys
+import os
+from datetime import datetime
+from pathlib import Path
+
+# Dangerous command patterns
+DANGEROUS_PATTERNS = [
+    # Direct rm -rf on critical paths
+    r'rm\s+(-[rfRF]+\s+|\s+-[rfRF]+)(/\s*$|/\s+|\s+/\s*$|\s+/\s+)',
+    r'rm\s+(-[rfRF]+\s+|\s+-[rfRF]+)(\*|\.\s*$|\.\.\s*$)',
+    r'rm\s+(-[rfRF]+\s+|\s+-[rfRF]+)(~|\$HOME|\${HOME})',
+
+    # Recursive + force with wildcards
+    r'rm\s+.*-r.*-f.*\*',
+    r'rm\s+.*-f.*-r.*\*',
+
+    # Long form options
+    r'rm\s+.*(--recursive|--force).*(/\s*$|\*)',
+
+    # Prevent removal of current directory or parent
+    r'rm\s+-[rfRF]+\s+\./?(\s|$)',
+    r'rm\s+-[rfRF]+\s+\.\./?(\s|$)',
+]
+
+# Additional context-aware checks
+CRITICAL_PATHS = [
+    '/',
+    '/etc',
+    '/usr',
+    '/bin',
+    '/sbin',
+    '/boot',
+    '/dev',
+    '/lib',
+    '/proc',
+    '/sys',
+    '/var',
+    os.path.expanduser('~'),
+]
+
+
+def is_dangerous_command(command: str) -> tuple[bool, str]:
+    """
+    Check if command is dangerous.
+    Returns (is_dangerous, reason)
+    """
+    # Check regex patterns
+    for pattern in DANGEROUS_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return True, f"Command matches dangerous pattern: {pattern}"
+
+    # Check for rm on critical paths
+    if 'rm' in command:
+        for critical_path in CRITICAL_PATHS:
+            if critical_path in command and '-r' in command:
+                return True, f"Recursive removal targeting critical path: {critical_path}"
+
+    # Check for multiple wildcards with force/recursive
+    if 'rm' in command and ('*' in command or '?' in command):
+        if '-rf' in command or '-fr' in command or ('-r' in command and '-f' in command):
+            wildcard_count = command.count('*') + command.count('?')
+            if wildcard_count > 1:
+                return True, "Multiple wildcards with force/recursive flags"
+
+    return False, ""
+
+
+def suggest_safer_alternative(command: str) -> str:
+    """Suggest a safer alternative to the dangerous command."""
+    suggestions = []
+
+    if 'rm -rf' in command or 'rm -fr' in command:
+        suggestions.append("• Use 'rm -r' without -f for important deletions (allows prompting)")
+        suggestions.append("• Specify exact paths instead of using wildcards")
+        suggestions.append("• Consider using 'trash' command to move to trash instead")
+        suggestions.append("• Use 'find' with -delete for more controlled deletion")
+
+    if '*' in command:
+        suggestions.append("• List files first with 'ls' before using wildcards")
+        suggestions.append("• Use specific file patterns instead of broad wildcards")
+
+    return "\n".join(suggestions) if suggestions else "Consider a more specific, safer command"
+
+
+def log_blocked_command(session_id: str, command: str, reason: str):
+    """Log blocked commands for security audit."""
+    try:
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+        log_dir = Path(project_dir) / "agents" / "security_logs" / session_id
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        log_file = log_dir / "blocked_commands.jsonl"
+        log_entry = {
+            "timestamp": datetime.now().isoformat(),
+            "command": command,
+            "reason": reason,
+            "action": "blocked"
+        }
+
+        with open(log_file, 'a') as f:
+            f.write(json.dumps(log_entry) + '\n')
+    except Exception:
+        # Silently fail logging - don't let it affect the blocking
+        pass
+
+
+def main():
+    try:
+        # Read input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Only process Bash tool calls
+        if input_data.get("tool_name") != "Bash":
+            sys.exit(0)
+
+        # Extract command
+        tool_input = input_data.get("tool_input", {})
+        command = tool_input.get("command", "")
+
+        if not command:
+            sys.exit(0)
+
+        # Check if command is dangerous
+        is_dangerous, reason = is_dangerous_command(command)
+
+        if is_dangerous:
+            # Log the blocked command for audit
+            session_id = input_data.get("session_id", "unknown")
+            log_blocked_command(session_id, command, reason)
+
+            # Provide detailed feedback to Claude
+            error_message = f"""BLOCKED: Dangerous command detected!
+
+Command: {command}
+Reason: {reason}
+
+This command could cause irreversible data loss or system damage.
+
+Safer alternatives:
+{suggest_safer_alternative(command)}
+
+Please reconsider your approach and use a safer command."""
+
+            print(error_message, file=sys.stderr)
+            sys.exit(2)  # Block execution and show stderr to Claude
+
+        # Command is safe, allow execution
+        sys.exit(0)
+
+    except json.JSONDecodeError as e:
+        print(f"Error parsing input: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        # Don't block on errors, just log
+        print(f"Hook error: {e}", file=sys.stderr)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/universal_hook_logger.py
+++ b/.claude/hooks/universal_hook_logger.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+"""
+Universal Hook Logger - Claude Code Hook
+Logs all hook payloads to session-specific JSONL files
+"""
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def get_hook_name(input_data: dict) -> str:
+    """Extract hook event name from input data."""
+    return input_data.get("hook_event_name", "Unknown")
+
+
+def create_log_entry(input_data: dict) -> dict:
+    """Create enriched log entry with timestamp and full payload."""
+    return {
+        "timestamp": datetime.now().isoformat(),
+        "payload": input_data
+    }
+
+
+def write_log_entry(session_id: str, hook_name: str, log_entry: dict) -> None:
+    """Write log entry to appropriate JSONL file."""
+    # Use CLAUDE_PROJECT_DIR if available, otherwise use cwd
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    
+    # Create directory structure relative to project root
+    log_dir = Path(project_dir) / "agents" / "hook_logs" / session_id
+    log_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Create hook-specific log file
+    log_file = log_dir / f"{hook_name}.jsonl"
+    
+    # Append to JSONL file
+    with open(log_file, 'a') as f:
+        f.write(json.dumps(log_entry) + '\n')
+
+
+def main():
+    try:
+        # Read hook input from stdin
+        input_data = json.load(sys.stdin)
+        
+        # Extract session ID and hook name
+        session_id = input_data.get("session_id", "unknown")
+        hook_name = get_hook_name(input_data)
+        
+        # Create and write log entry
+        log_entry = create_log_entry(input_data)
+        write_log_entry(session_id, hook_name, log_entry)
+        
+        # Success - exit silently
+        sys.exit(0)
+        
+    except Exception as e:
+        # Log error but don't block hook execution
+        print(f"Hook logger error: {e}", file=sys.stderr)
+        sys.exit(0)  # Non-blocking error
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,37 @@
 {
-  "model": "claude-sonnet-4-5"
+  "model": "claude-sonnet-4-5",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/dangerous_command_blocker.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/universal_hook_logger.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/universal_hook_logger.py"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ test_*.kicad_sch
 /logs/
 /manual_tests/
 /temp_test_env/
+
+# Hook logs (runtime generated)
+.claude/hook_logs/


### PR DESCRIPTION
## Summary

Removes shared-library submodule approach and replaces with direct integration of hooks and domain-specific commands tailored to kicad-sch-api workflows.

## Problem

The generic `FULL_WORKFLOW.md` from shared-library doesn't capture kicad-sch-api's unique development patterns:
- Reference schematic creation (agent creates → user edits in KiCad GUI → agent analyzes S-expression)
- Format preservation validation (byte-perfect matching)
- Parser/formatter debugging with strategic Python logging
- Interactive manual validation in KiCad GUI

Generic workflows don't work - each repo needs domain-specific patterns.

## Changes

### Hooks Added (3 files)
- `dangerous_command_blocker.py` - Prevents destructive bash commands (rm -rf /, etc.)
- `universal_hook_logger.py` - Logs all tool usage for development observability
- `context_bundle_builder.py` - Development utilities

### Domain-Specific Commands Added (10 commands)

**Dev Commands (6):**
- `/dev` - Complete KiCad development workflow (1314 lines)
  - Reference schematic workflow: agent creates blank → user edits in KiCad → agent analyzes
  - S-expression format analysis and validation patterns
  - Python logging patterns for parser/formatter debugging
  - Iterative development cycle (max 8 attempts)
  - Phase 4.5: Interactive manual validation in KiCad GUI
  - Format preservation validation (byte-perfect vs semantic equivalence)
  - PR fixing workflow for existing PRs with failing CI
- `/publish-pypi` - PyPI release automation with validation
- `/review-implementation` - Code review utilities
- `/run-tests` - Test execution helpers
- `/update-and-commit` - Git workflow helpers
- `/dead-code-analysis` - Code cleanup utilities

**Test Commands (1):**
- `/run-reference-tests` - Reference test runner

**User Commands (3):**
- `/create-schematic` - Schematic creation helper
- `/generate-circuit` - Circuit generation guide
- `/troubleshoot-library` - Library setup troubleshooting

### Configuration
- Updated `.claude/settings.json` with hooks configuration
- Updated `.gitignore` to exclude runtime-generated hook logs

## What Was Removed

- ❌ shared-library git submodule
- ❌ Generic `FULL_WORKFLOW.md` (doesn't fit kicad-sch-api)
- ❌ Generic synced commands (plan, ref-gen, test-gen, code, review, etc.)
- ❌ `sync_commands.py` script (not using submodule approach)

## Rationale

**Domain-specific workflows are essential.** The `/dev` command (1314 lines) captures kicad-sch-api's unique patterns:

1. **Reference Schematic Creation**
   - Agent creates blank schematic using kicad-sch-api
   - Opens in KiCad GUI for user to add/configure elements
   - Agent analyzes saved S-expression to understand exact KiCad format

2. **Format Preservation Focus**
   - Byte-perfect output matching KiCad's native format
   - S-expression structure analysis and replication
   - Round-trip validation (load → save → compare)

3. **Python Logging Patterns**
   - Strategic debug logging in parser/formatter
   - Log-driven hypothesis formation
   - Iterative debugging cycle (8 attempts max)

4. **Interactive Validation**
   - Phase 4.5: Manual validation in KiCad GUI
   - Guided step-by-step user verification
   - Automated tests + human validation (belt-and-suspenders)

These patterns are specific to KiCad schematic manipulation and format preservation - they don't generalize to other circuit-synth repos.

## Testing

- ✅ Hooks copied and configured
- ✅ Settings.json includes hook configuration
- ✅ Commands accessible via `/dev`, `/publish-pypi`, etc.
- ✅ No submodule dependencies
- ✅ gitignore excludes hook logs

## Philosophy

Each circuit-synth repo should have domain-specific commands:
- **kicad-sch-api**: Reference schematics → S-expression → format preservation
- **circuit-synth**: Component sourcing → DFM → JLCPCB integration
- **circuit-intelligence**: Pattern recognition → analysis → recommendations

Copy hooks. Build your own commands. No generic workflows.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>