### PR TITLE
feat: Add pin enumeration utilities (list_pins, show_pins) (#179)

### DIFF
--- a/kicad_sch_api/collections/components.py
+++ b/kicad_sch_api/collections/components.py
@@ -375,6 +375,61 @@ class Component:
         """
         return self._data.get_pin_position(pin_number)
 
+    def list_pins(self) -> List[Dict[str, Any]]:
+        """
+        List all pins for this component.
+
+        Returns:
+            List of pin dictionaries with keys:
+            - number: Pin number (str)
+            - name: Pin name (str)
+            - type: Pin electrical type (str)
+            - position: Absolute pin position (Point)
+
+        Example:
+            >>> comp = sch.components.get("U1")
+            >>> pins = comp.list_pins()
+            >>> for pin in pins:
+            ...     print(f"Pin {pin['number']}: {pin['name']} ({pin['type']})")
+            Pin 1: GND (POWER_IN)
+            Pin 2: 3V3 (POWER_IN)
+        """
+        return [
+            {
+                "number": pin.number,
+                "name": pin.name,
+                "type": pin.pin_type.value,
+                "position": pin.position,
+            }
+            for pin in self._data.pins
+        ]
+
+    def show_pins(self) -> None:
+        """
+        Display pin information in readable table format.
+
+        Prints a formatted table showing pin numbers, names, and types
+        for all pins on this component. Useful for interactive exploration
+        and debugging.
+
+        Example:
+            >>> comp = sch.components.get("U1")
+            >>> comp.show_pins()
+
+            Pins for U1 (RF_Module:ESP32-WROOM-32):
+            Pin#   Name                 Type
+            ----------------------------------------
+            1      GND                  POWER_IN
+            2      3V3                  POWER_IN
+            3      EN                   INPUT
+            ...
+        """
+        print(f"\nPins for {self.reference} ({self.lib_id}):")
+        print(f"{'Pin#':<6} {'Name':<20} {'Type':<12}")
+        print("-" * 40)
+        for pin in self._data.pins:
+            print(f"{pin.number:<6} {pin.name:<20} {pin.pin_type.value:<12}")
+
     # Component state flags
     @property
     def in_bom(self) -> bool:

--- a/kicad_sch_api/core/components.py
+++ b/kicad_sch_api/core/components.py
@@ -193,6 +193,61 @@ class Component:
         """Get absolute position of pin."""
         return self._data.get_pin_position(pin_number)
 
+    def list_pins(self) -> List[Dict[str, Any]]:
+        """
+        List all pins for this component.
+
+        Returns:
+            List of pin dictionaries with keys:
+            - number: Pin number (str)
+            - name: Pin name (str)
+            - type: Pin electrical type (str)
+            - position: Absolute pin position (Point)
+
+        Example:
+            >>> comp = sch.components.get("U1")
+            >>> pins = comp.list_pins()
+            >>> for pin in pins:
+            ...     print(f"Pin {pin['number']}: {pin['name']} ({pin['type']})")
+            Pin 1: GND (POWER_IN)
+            Pin 2: 3V3 (POWER_IN)
+        """
+        return [
+            {
+                "number": pin.number,
+                "name": pin.name,
+                "type": pin.pin_type.value,
+                "position": pin.position,
+            }
+            for pin in self.pins
+        ]
+
+    def show_pins(self) -> None:
+        """
+        Display pin information in readable table format.
+
+        Prints a formatted table showing pin numbers, names, and types
+        for all pins on this component. Useful for interactive exploration
+        and debugging.
+
+        Example:
+            >>> comp = sch.components.get("U1")
+            >>> comp.show_pins()
+
+            Pins for U1 (RF_Module:ESP32-WROOM-32):
+            Pin#   Name                 Type
+            ----------------------------------------
+            1      GND                  POWER_IN
+            2      3V3                  POWER_IN
+            3      EN                   INPUT
+            ...
+        """
+        print(f"\nPins for {self.reference} ({self.lib_id}):")
+        print(f"{'Pin#':<6} {'Name':<20} {'Type':<12}")
+        print("-" * 40)
+        for pin in self.pins:
+            print(f"{pin.number:<6} {pin.name:<20} {pin.pin_type.value:<12}")
+
     # Component state
     @property
     def in_bom(self) -> bool:

--- a/tests/unit/test_pin_utilities.py
+++ b/tests/unit/test_pin_utilities.py
@@ -1,0 +1,249 @@
+"""
+Unit tests for pin utility methods (list_pins, show_pins).
+
+Tests the new pin enumeration functionality that makes it easy for users
+to discover and inspect component pins without needing to know them in advance.
+"""
+
+import io
+import sys
+
+import pytest
+
+import kicad_sch_api as ksa
+
+
+class TestListPinsMethod:
+    """Test the list_pins() method."""
+
+    def test_list_pins_returns_list(self):
+        """list_pins() should return a list."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        assert isinstance(pins, list)
+
+    def test_list_pins_resistor_has_two_pins(self):
+        """Resistor should have exactly 2 pins."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        assert len(pins) == 2
+
+    def test_list_pins_dict_structure(self):
+        """Each pin dict should have required keys."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        # Check first pin has all required keys
+        pin = pins[0]
+        assert "number" in pin
+        assert "name" in pin
+        assert "type" in pin
+        assert "position" in pin
+
+    def test_list_pins_number_is_string(self):
+        """Pin number should be a string."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        for pin in pins:
+            assert isinstance(pin["number"], str)
+
+    def test_list_pins_name_is_string(self):
+        """Pin name should be a string."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        for pin in pins:
+            assert isinstance(pin["name"], str)
+
+    def test_list_pins_type_is_string(self):
+        """Pin type should be a string."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        for pin in pins:
+            assert isinstance(pin["type"], str)
+
+    def test_list_pins_position_is_point(self):
+        """Pin position should be a Point object."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        for pin in pins:
+            # Should have x and y attributes
+            assert hasattr(pin["position"], "x")
+            assert hasattr(pin["position"], "y")
+
+    def test_list_pins_resistor_pin_numbers(self):
+        """Resistor pins should be numbered 1 and 2."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+        pin_numbers = {p["number"] for p in pins}
+
+        assert "1" in pin_numbers
+        assert "2" in pin_numbers
+
+    def test_list_pins_programmatic_iteration(self):
+        """Should be able to programmatically iterate pins."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        # Should be able to filter/process pins
+        pin_numbers = [p["number"] for p in pins]
+        pin_names = [p["name"] for p in pins]
+        pin_types = [p["type"] for p in pins]
+
+        assert len(pin_numbers) == 2
+        assert len(pin_names) == 2
+        assert len(pin_types) == 2
+
+
+class TestShowPinsMethod:
+    """Test the show_pins() method."""
+
+    def test_show_pins_produces_output(self, capsys):
+        """show_pins() should print output."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        r1.show_pins()
+
+        captured = capsys.readouterr()
+        assert len(captured.out) > 0
+
+    def test_show_pins_displays_reference(self, capsys):
+        """show_pins() should display component reference."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        r1.show_pins()
+
+        captured = capsys.readouterr()
+        assert "R1" in captured.out
+
+    def test_show_pins_displays_lib_id(self, capsys):
+        """show_pins() should display lib_id."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        r1.show_pins()
+
+        captured = capsys.readouterr()
+        assert "Device:R" in captured.out
+
+    def test_show_pins_has_header(self, capsys):
+        """show_pins() should have column headers."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        r1.show_pins()
+
+        captured = capsys.readouterr()
+        assert "Pin#" in captured.out
+        assert "Name" in captured.out
+        assert "Type" in captured.out
+
+    def test_show_pins_displays_pin_numbers(self, capsys):
+        """show_pins() should display pin numbers."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        r1.show_pins()
+
+        captured = capsys.readouterr()
+        # Resistor should have pins 1 and 2
+        assert "1" in captured.out
+        assert "2" in captured.out
+
+    def test_show_pins_formatting_has_separator(self, capsys):
+        """show_pins() output should have separator line."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        r1.show_pins()
+
+        captured = capsys.readouterr()
+        # Should have a separator line with dashes
+        assert "-" * 10 in captured.out
+
+
+class TestRealWorldUsage:
+    """Test real-world usage scenarios."""
+
+    def test_discover_pins_without_knowing_in_advance(self):
+        """User can discover pins without prior knowledge."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        # User doesn't know what pins a resistor has
+        pins = r1.list_pins()
+
+        # But can now discover them
+        assert len(pins) > 0
+        first_pin = pins[0]
+        assert first_pin["number"] is not None
+        assert first_pin["name"] is not None
+
+    def test_find_specific_pin_type(self):
+        """User can filter pins by type."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        # Filter for passive pins
+        passive_pins = [p for p in pins if p["type"] == "passive"]
+
+        # Resistor pins should be passive
+        assert len(passive_pins) > 0
+
+    def test_check_if_component_has_pin(self):
+        """User can check if component has specific pin."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+        pin_numbers = {p["number"] for p in pins}
+
+        # Check if pin 1 exists
+        assert "1" in pin_numbers
+
+        # Check if pin 99 exists (should not)
+        assert "99" not in pin_numbers
+
+    def test_get_pin_positions_for_routing(self):
+        """User can get pin positions for wire routing."""
+        sch = ksa.create_schematic("Test")
+        r1 = sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+
+        pins = r1.list_pins()
+
+        # Get position of first pin for routing
+        pin1 = next(p for p in pins if p["number"] == "1")
+        pos = pin1["position"]
+
+        # Position should be valid
+        assert pos.x is not None
+        assert pos.y is not None
+        assert isinstance(pos.x, (int, float))
+        assert isinstance(pos.y, (int, float))


### PR DESCRIPTION
## Summary

Adds pin enumeration utilities to make pin discovery easy for users. Users no longer need to know component pins in advance - they can simply call `list_pins()` or `show_pins()` to discover them.

## Changes

- ✅ Added `list_pins()` method to `Component` class - returns `List[Dict[str, Any]]`
- ✅ Added `show_pins()` method to `Component` class - prints formatted table
- ✅ Added `list_pins()` method to `ComponentProxy` class
- ✅ Added `show_pins()` method to `ComponentProxy` class  
- ✅ Added comprehensive test suite (19 tests) in `test_pin_utilities.py`
- ✅ All tests passing (19/19)

## Example Usage

### Programmatic Pin Discovery

```python
import kicad_sch_api as ksa

sch = ksa.create_schematic("Test")
esp32 = sch.components.add('RF_Module:ESP32-WROOM-32', 'U1', 'ESP32')

# List pins programmatically
pins = esp32.list_pins()
print(f"ESP32 has {len(pins)} pins")

for pin in pins:
    print(f"Pin {pin['number']}: {pin['name']} ({pin['type']})")
    
# Filter for power pins
power_pins = [p for p in pins if 'POWER' in p['type']]
```

### Interactive Pin Display

```python
# Display formatted table
esp32.show_pins()

# Output:
# Pins for U1 (RF_Module:ESP32-WROOM-32):
# Pin#   Name                 Type
# ----------------------------------------
# 1      GND                  POWER_IN
# 2      3V3                  POWER_IN
# 3      EN                   INPUT
# ...
```

## Testing

```bash
uv run pytest tests/unit/test_pin_utilities.py -v
# 19 passed in 0.35s
```

## Benefits

- ✅ No need to know pins in advance
- ✅ Easy discovery in interactive sessions (Jupyter, REPL)
- ✅ Programmatic pin filtering and processing  
- ✅ Helps write design checkers and validators
- ✅ Better developer experience

## Related Issues

- Implements #179 Phase 1
- Requested by user feedback (Tom Anderson)
- Documented in PIN_UTILITIES_RESEARCH.md

## Next Steps

Future phases (#179):
- Phase 2: Library inspection before placing components
- Phase 3: Search functionality
- Phase 4: Rich display for Jupyter notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)