### PR TITLE
feat: Add Jupyter/IPython rich display (Issue #179 Phase 4)

### DIFF
--- a/kicad_sch_api/library/cache.py
+++ b/kicad_sch_api/library/cache.py
@@ -189,6 +189,135 @@ class SymbolDefinition:
             pin_type = pin.pin_type.value if hasattr(pin.pin_type, "value") else str(pin.pin_type)
             print(f"{pin.number:<6} {pin.name:<20} {pin_type:<12}")
 
+    def _repr_html_(self) -> str:
+        """
+        Generate rich HTML representation for Jupyter/IPython notebooks.
+
+        Returns:
+            HTML string with symbol information formatted as styled table
+        """
+        # Symbol header with name and library
+        html = f"""
+        <div style="border: 1px solid #ddd; border-radius: 8px; padding: 15px; margin: 10px 0; font-family: Arial, sans-serif;">
+            <h3 style="margin: 0 0 10px 0; color: #333;">
+                {self.lib_id}
+            </h3>
+            <p style="color: #666; margin: 5px 0;">
+                <strong>Library:</strong> {self.library} &nbsp;&nbsp;
+                <strong>Reference Prefix:</strong> {self.reference_prefix}
+            </p>
+        """
+
+        # Description
+        if self.description:
+            html += f"""
+            <p style="color: #555; margin: 10px 0; font-style: italic;">
+                {self.description}
+            </p>
+            """
+
+        # Keywords
+        if self.keywords:
+            html += f"""
+            <p style="color: #888; font-size: 0.9em; margin: 5px 0;">
+                <strong>Keywords:</strong> {self.keywords}
+            </p>
+            """
+
+        # Datasheet link
+        if self.datasheet:
+            html += f"""
+            <p style="margin: 5px 0;">
+                <strong>Datasheet:</strong> <a href="{self.datasheet}" target="_blank">{self.datasheet}</a>
+            </p>
+            """
+
+        # Symbol properties
+        properties = []
+        if self.power_symbol:
+            properties.append("Power Symbol")
+        if self.units > 1:
+            properties.append(f"{self.units} Units")
+        if self.extends:
+            properties.append(f"Extends: {self.extends}")
+
+        if properties:
+            html += f"""
+            <p style="margin: 5px 0; color: #555;">
+                <strong>Properties:</strong> {", ".join(properties)}
+            </p>
+            """
+
+        # Pins table
+        if self.pins:
+            html += """
+            <h4 style="margin: 15px 0 10px 0; color: #444;">Pins</h4>
+            <table style="border-collapse: collapse; width: 100%; font-size: 0.9em;">
+                <thead>
+                    <tr style="background-color: #f5f5f5; border-bottom: 2px solid #ddd;">
+                        <th style="padding: 8px; text-align: left; border: 1px solid #ddd;">Pin #</th>
+                        <th style="padding: 8px; text-align: left; border: 1px solid #ddd;">Name</th>
+                        <th style="padding: 8px; text-align: left; border: 1px solid #ddd;">Type</th>
+                    </tr>
+                </thead>
+                <tbody>
+            """
+
+            for pin in self.pins:
+                pin_type = (
+                    pin.pin_type.value if hasattr(pin.pin_type, "value") else str(pin.pin_type)
+                )
+                # Color code pin types
+                type_color = {
+                    "input": "#4CAF50",
+                    "output": "#2196F3",
+                    "bidirectional": "#9C27B0",
+                    "tri_state": "#9C27B0",
+                    "passive": "#757575",
+                    "unspecified": "#757575",
+                    "power_in": "#F44336",
+                    "power_out": "#FF9800",
+                    "open_collector": "#00BCD4",
+                    "open_emitter": "#00BCD4",
+                    "unconnected": "#9E9E9E",
+                }.get(pin_type, "#333")
+
+                html += f"""
+                <tr style="border-bottom: 1px solid #eee;">
+                    <td style="padding: 8px; border: 1px solid #ddd; font-family: monospace;">{pin.number}</td>
+                    <td style="padding: 8px; border: 1px solid #ddd;">{pin.name}</td>
+                    <td style="padding: 8px; border: 1px solid #ddd; color: {type_color}; font-weight: 500;">
+                        {pin_type}
+                    </td>
+                </tr>
+                """
+
+            html += """
+                </tbody>
+            </table>
+            """
+        else:
+            html += """
+            <p style="color: #888; font-style: italic; margin: 10px 0;">No pins defined</p>
+            """
+
+        # Metadata footer
+        metadata = []
+        if len(self.pins) > 0:
+            metadata.append(f"{len(self.pins)} pins")
+        if len(self.graphic_elements) > 0:
+            metadata.append(f"{len(self.graphic_elements)} graphic elements")
+
+        if metadata:
+            html += f"""
+            <p style="margin-top: 15px; padding-top: 10px; border-top: 1px solid #eee; color: #999; font-size: 0.8em;">
+                {" • ".join(metadata)}
+            </p>
+            """
+
+        html += "</div>"
+        return html
+
 
 @dataclass
 class LibraryStats:

--- a/tests/unit/test_jupyter_display.py
+++ b/tests/unit/test_jupyter_display.py
@@ -1,0 +1,441 @@
+"""
+Unit tests for Jupyter/IPython rich display (Issue #179 Phase 4).
+
+Tests the _repr_html_() method for SymbolDefinition to enable rich display
+in Jupyter notebooks.
+"""
+
+import pytest
+
+from kicad_sch_api.core.types import PinType, Point, SchematicPin
+from kicad_sch_api.library.cache import SymbolDefinition
+
+
+class TestSymbolDefinitionReprHtml:
+    """Test SymbolDefinition._repr_html_() method."""
+
+    def test_repr_html_returns_string(self):
+        """Should return HTML string."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+        )
+
+        html = symbol._repr_html_()
+
+        assert isinstance(html, str)
+        assert len(html) > 0
+
+    def test_repr_html_contains_lib_id(self):
+        """Should display lib_id."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Device:R" in html
+
+    def test_repr_html_contains_library_and_prefix(self):
+        """Should display library and reference prefix."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Device" in html
+        assert "Reference Prefix" in html
+
+    def test_repr_html_includes_description(self):
+        """Should display description when available."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+            description="Resistor component",
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Resistor component" in html
+
+    def test_repr_html_includes_keywords(self):
+        """Should display keywords when available."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+            keywords="passive component",
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Keywords" in html
+        assert "passive component" in html
+
+    def test_repr_html_includes_datasheet_link(self):
+        """Should display clickable datasheet link."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+            datasheet="https://example.com/datasheet.pdf",
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Datasheet" in html
+        assert "https://example.com/datasheet.pdf" in html
+        assert "href=" in html
+
+    def test_repr_html_shows_power_symbol(self):
+        """Should indicate power symbols."""
+        symbol = SymbolDefinition(
+            lib_id="power:GND",
+            name="GND",
+            library="power",
+            reference_prefix="#PWR",
+            power_symbol=True,
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Power Symbol" in html
+
+    def test_repr_html_shows_multi_unit_symbol(self):
+        """Should show unit count for multi-unit symbols."""
+        symbol = SymbolDefinition(
+            lib_id="Amplifier_Operational:TL072",
+            name="TL072",
+            library="Amplifier_Operational",
+            reference_prefix="U",
+            units=3,
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Units" in html
+
+    def test_repr_html_shows_extends(self):
+        """Should show parent symbol when extending."""
+        symbol = SymbolDefinition(
+            lib_id="Custom:SpecialR",
+            name="SpecialR",
+            library="Custom",
+            reference_prefix="R",
+            extends="R",
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Extends" in html
+
+    def test_repr_html_includes_pins_table(self):
+        """Should display pins in HTML table."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+            pins=[
+                SchematicPin(
+                    number="1",
+                    name="~",
+                    pin_type=PinType.PASSIVE,
+                    position=Point(0, 0),
+                ),
+                SchematicPin(
+                    number="2",
+                    name="~",
+                    pin_type=PinType.PASSIVE,
+                    position=Point(0, 0),
+                ),
+            ],
+        )
+
+        html = symbol._repr_html_()
+
+        assert "Pins" in html
+        assert "<table" in html
+        assert "Pin #" in html
+        assert "Name" in html
+        assert "Type" in html
+
+    def test_repr_html_shows_pin_details(self):
+        """Should show pin number, name, and type."""
+        symbol = SymbolDefinition(
+            lib_id="Custom:Test",
+            name="Test",
+            library="Custom",
+            reference_prefix="U",
+            pins=[
+                SchematicPin(
+                    number="1",
+                    name="VCC",
+                    pin_type=PinType.POWER_IN,
+                    position=Point(0, 0),
+                )
+            ],
+        )
+
+        html = symbol._repr_html_()
+
+        assert "1" in html  # Pin number
+        assert "VCC" in html  # Pin name
+        assert "power_in" in html.lower()  # Pin type (case-insensitive check)
+
+    def test_repr_html_no_pins_message(self):
+        """Should show message when no pins."""
+        symbol = SymbolDefinition(
+            lib_id="Custom:NoPins",
+            name="NoPins",
+            library="Custom",
+            reference_prefix="U",
+        )
+
+        html = symbol._repr_html_()
+
+        assert "No pins defined" in html
+
+    def test_repr_html_includes_metadata(self):
+        """Should display metadata footer."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+            pins=[
+                SchematicPin(
+                    number="1",
+                    name="~",
+                    pin_type=PinType.PASSIVE,
+                    position=Point(0, 0),
+                )
+            ],
+            graphic_elements=[{"type": "rectangle"}],
+        )
+
+        html = symbol._repr_html_()
+
+        assert "pins" in html
+        assert "graphic elements" in html
+
+    def test_repr_html_styling(self):
+        """Should include CSS styling."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+        )
+
+        html = symbol._repr_html_()
+
+        # Check for inline styles
+        assert "style=" in html
+        assert "border" in html
+        assert "color" in html
+
+    def test_repr_html_pin_type_colors(self):
+        """Should color-code different pin types."""
+        symbol = SymbolDefinition(
+            lib_id="Custom:MultiType",
+            name="MultiType",
+            library="Custom",
+            reference_prefix="U",
+            pins=[
+                SchematicPin(
+                    number="1",
+                    name="IN",
+                    pin_type=PinType.INPUT,
+                    position=Point(0, 0),
+                ),
+                SchematicPin(
+                    number="2",
+                    name="OUT",
+                    pin_type=PinType.OUTPUT,
+                    position=Point(0, 0),
+                ),
+                SchematicPin(
+                    number="3",
+                    name="VCC",
+                    pin_type=PinType.POWER_IN,
+                    position=Point(0, 0),
+                ),
+            ],
+        )
+
+        html = symbol._repr_html_()
+
+        # Should contain color codes (hex colors start with #)
+        assert "#" in html
+        # Different pins should have different colors
+        # (This is a basic check - could be more sophisticated)
+        assert html.count("color:") >= 3
+
+
+class TestJupyterDisplayIntegration:
+    """Integration tests for Jupyter display."""
+
+    def test_symbol_displays_in_notebook_environment(self):
+        """Should work with IPython/Jupyter display system."""
+        symbol = SymbolDefinition(
+            lib_id="Device:R",
+            name="R",
+            library="Device",
+            reference_prefix="R",
+            description="Resistor",
+            pins=[
+                SchematicPin(
+                    number="1",
+                    name="~",
+                    pin_type=PinType.PASSIVE,
+                    position=Point(0, 0),
+                ),
+                SchematicPin(
+                    number="2",
+                    name="~",
+                    pin_type=PinType.PASSIVE,
+                    position=Point(0, 0),
+                ),
+            ],
+        )
+
+        # IPython/Jupyter looks for _repr_html_ method
+        assert hasattr(symbol, "_repr_html_")
+        assert callable(symbol._repr_html_)
+
+        # Calling it should return valid HTML
+        html = symbol._repr_html_()
+        assert "<div" in html
+        assert "</div>" in html
+
+
+class TestRealWorldUsageScenarios:
+    """Test real-world usage patterns in Jupyter."""
+
+    def test_display_search_results(self):
+        """User searches and displays results in notebook."""
+        # Create mock search results
+        resistors = [
+            SymbolDefinition(
+                lib_id="Device:R",
+                name="R",
+                library="Device",
+                reference_prefix="R",
+                description="Resistor",
+            ),
+            SymbolDefinition(
+                lib_id="Device:R_Variable",
+                name="R_Variable",
+                library="Device",
+                reference_prefix="R",
+                description="Variable resistor",
+            ),
+        ]
+
+        # Each should have HTML representation
+        for symbol in resistors:
+            html = symbol._repr_html_()
+            assert "Device" in html
+            assert "resistor" in html.lower()
+
+    def test_display_esp32_with_many_pins(self):
+        """User displays ESP32 module with many pins."""
+        # Create ESP32-like symbol with multiple pins
+        pins = []
+        pin_names = ["GND", "VCC", "EN", "GPIO0", "GPIO2", "TXD", "RXD"]
+        for i, name in enumerate(pin_names, 1):
+            pins.append(
+                SchematicPin(
+                    number=str(i),
+                    name=name,
+                    pin_type=PinType.POWER_IN if name in ["GND", "VCC"] else PinType.BIDIRECTIONAL,
+                    position=Point(0, 0),
+                )
+            )
+
+        esp32 = SymbolDefinition(
+            lib_id="RF_Module:ESP32-WROOM-32",
+            name="ESP32-WROOM-32",
+            library="RF_Module",
+            reference_prefix="U",
+            description="WiFi/Bluetooth module",
+            pins=pins,
+        )
+
+        html = esp32._repr_html_()
+
+        # Should display all pins
+        for name in pin_names:
+            assert name in html
+
+        # Should have table structure
+        assert "<table" in html
+        assert "<tr" in html
+        assert "<td" in html
+
+    def test_display_power_symbol(self):
+        """User displays power supply symbol."""
+        gnd = SymbolDefinition(
+            lib_id="power:GND",
+            name="GND",
+            library="power",
+            reference_prefix="#PWR",
+            description="Ground symbol",
+            power_symbol=True,
+            pins=[
+                SchematicPin(
+                    number="1",
+                    name="GND",
+                    pin_type=PinType.POWER_IN,
+                    position=Point(0, 0),
+                )
+            ],
+        )
+
+        html = gnd._repr_html_()
+
+        # Should indicate it's a power symbol
+        assert "Power Symbol" in html
+        assert "GND" in html
+
+    def test_compare_symbols_side_by_side(self):
+        """User compares multiple symbols."""
+        symbols = [
+            SymbolDefinition(
+                lib_id="Device:R",
+                name="R",
+                library="Device",
+                reference_prefix="R",
+                description="Resistor",
+                pins=[SchematicPin("1", "~", PinType.PASSIVE, Point(0, 0))],
+            ),
+            SymbolDefinition(
+                lib_id="Device:C",
+                name="C",
+                library="Device",
+                reference_prefix="C",
+                description="Capacitor",
+                pins=[SchematicPin("1", "~", PinType.PASSIVE, Point(0, 0))],
+            ),
+        ]
+
+        # Each should have unique HTML
+        htmls = [s._repr_html_() for s in symbols]
+
+        assert len(htmls) == 2
+        assert "Resistor" in htmls[0]
+        assert "Capacitor" in htmls[1]


### PR DESCRIPTION
## Summary

Implements Phase 4 of Issue #179: Rich HTML display for symbols in Jupyter notebooks and IPython environments.

## Changes

- **`SymbolDefinition._repr_html_()`**: Generate styled HTML representation
- **Color-coded pin types**: Visual differentiation (input=green, output=blue, power=red, etc.)
- **Styled tables**: Professional-looking tables with borders and formatting
- **Clickable datasheet links**: Direct links to component datasheets
- **Metadata display**: Shows pin counts, graphic elements, power symbol indicators
- **Comprehensive test suite**: 20 tests (all passing)

## Features

### Visual Enhancements
- Bordered, rounded containers with clean styling
- Color-coded pin types for easy identification
- Professional table layout with headers
- Metadata footer showing component statistics

### Information Display
- Symbol name and library
- Reference prefix
- Description and keywords
- Datasheet links (clickable)
- Power symbol indicator
- Multi-unit symbol information
- Symbol inheritance (extends)
- Complete pin table with numbers, names, and types

## Example Usage

```python
import kicad_sch_api as ksa

# In Jupyter notebook - displays beautiful HTML automatically
symbol = ksa.get_symbol_info('RF_Module:ESP32-WROOM-32')
symbol  # Rich HTML display appears!

# Or search and display results
resistors = ksa.search_symbols('resistor', library='Device')
for r in resistors[:3]:
    display(r)  # Each displays as styled HTML
```

## Visual Example

The HTML output includes:
- Symbol header with lib_id
- Library and reference prefix info
- Description in italics
- Keywords section
- Clickable datasheet link
- Pin table with color-coded types
- Metadata footer

## Pin Type Colors

- Input: Green (#4CAF50)
- Output: Blue (#2196F3)
- Bidirectional: Purple (#9C27B0)
- Power In: Red (#F44336)
- Power Out: Orange (#FF9800)
- Passive: Gray (#757575)

## Testing

All tests pass:
- 20 passed (100% pass rate)

```bash
uv run python -m pytest tests/unit/test_jupyter_display.py -v
```

## Related Issues

Closes #179 Phase 4
Completes Issue #179 (all phases done)

## Dependencies

No new dependencies required - uses standard IPython/Jupyter `_repr_html_()` protocol.