### PR TITLE
fix(connectivity): Use list instead of set for Net objects

### DIFF
--- a/kicad_sch_api/core/connectivity.py
+++ b/kicad_sch_api/core/connectivity.py
@@ -242,10 +242,13 @@ class ConnectivityAnalyzer:
             wire_points: Points along the wire
         """
         # Check if any of these pins are already in a net
-        existing_nets = set()
+        # Use list instead of set since Net objects are mutable (not hashable)
+        existing_nets = []
         for pin in pins:
             if pin in self._pin_to_net:
-                existing_nets.add(self._pin_to_net[pin])
+                net = self._pin_to_net[pin]
+                if net not in existing_nets:
+                    existing_nets.append(net)
 
         if existing_nets:
             # Merge all existing nets into the first one


### PR DESCRIPTION
## Summary

- Fix `TypeError: unhashable type: 'Net'` in `ConnectivityAnalyzer._add_wire_to_net()`
- Change `existing_nets` from `set()` to `list()` since `Net` objects are mutable and should not be hashable

## Problem

When analyzing schematics with multiple wires connecting to the same pins, the connectivity analyzer crashed:

```python
existing_nets = set()
for pin in pins:
    if pin in self._pin_to_net:
        existing_nets.add(self._pin_to_net[pin])  # TypeError: unhashable type: 'Net'
```

`Net` is a mutable dataclass (has `merge()`, `add_pin()` methods) and correctly does not define `__hash__`. But the code tried to add Net objects to a Python set.

## Solution

Use a list with membership check instead:

```python
existing_nets = []
for pin in pins:
    if pin in self._pin_to_net:
        net = self._pin_to_net[pin]
        if net not in existing_nets:
            existing_nets.append(net)
```

## Test plan

- [x] All 53 hierarchical connectivity tests pass
- [x] Tested on real Motor Driver schematic (101 nets, 113 components)
- [x] Existing ERC tests unaffected (were already failing before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)