### PR TITLE
Add label justification support to add_label methods

### DIFF
--- a/kicad_sch_api/core/labels.py
+++ b/kicad_sch_api/core/labels.py
@@ -150,6 +150,8 @@ class LabelCollection(BaseCollection[LabelElement]):
         rotation: float = 0.0,
         size: float = 1.27,
         label_uuid: Optional[str] = None,
+        justify_h: str = "left",
+        justify_v: str = "bottom",
     ) -> LabelElement:
         """
         Add a new label element to the schematic.
@@ -160,6 +162,8 @@ class LabelCollection(BaseCollection[LabelElement]):
             rotation: Label rotation in degrees
             size: Label text size
             label_uuid: Specific UUID for label (auto-generated if None)
+            justify_h: Horizontal justification ("left", "right", "center")
+            justify_v: Vertical justification ("top", "bottom", "center")
 
         Returns:
             Newly created LabelElement
@@ -194,6 +198,8 @@ class LabelCollection(BaseCollection[LabelElement]):
             text=text.strip(),
             rotation=rotation,
             size=size,
+            justify_h=justify_h,
+            justify_v=justify_v,
         )
 
         # Create wrapper and add to collection

--- a/kicad_sch_api/core/schematic.py
+++ b/kicad_sch_api/core/schematic.py
@@ -818,6 +818,8 @@ class Schematic:
         uuid: Optional[str] = None,
         grid_units: Optional[bool] = None,
         grid_size: Optional[float] = None,
+        justify_h: Optional[str] = None,
+        justify_v: Optional[str] = None,
     ) -> str:
         """
         Add a text label to the schematic.
@@ -832,6 +834,8 @@ class Schematic:
             uuid: Specific UUID for label (auto-generated if None)
             grid_units: If True, interpret position as grid units; if None, use config.positioning.use_grid_units
             grid_size: Grid size in mm; if None, use config.positioning.grid_size
+            justify_h: Horizontal justification ("left", "right", "center") - auto-calculated if pin provided
+            justify_v: Vertical justification ("top", "bottom", "center")
 
         Returns:
             UUID of created label
@@ -861,9 +865,11 @@ class Schematic:
         if position is not None and pin is not None:
             raise ValueError("Cannot provide both position and pin")
 
-        # Handle pin-based placement
-        justify_h = "left"
-        justify_v = "bottom"
+        # Handle pin-based placement - use provided justify or defaults
+        if justify_h is None:
+            justify_h = "left"
+        if justify_v is None:
+            justify_v = "bottom"
 
         if pin is not None:
             component_ref, pin_number = pin


### PR DESCRIPTION
## Summary
- Add `justify_h` and `justify_v` parameters to `LabelCollection.add()` in labels.py
- Add `justify_h` and `justify_v` parameters to `Schematic.add_label()` in schematic.py

This allows specifying horizontal and vertical text justification when creating labels, which is essential for proper label placement on component pins at different orientations.

Parameters default to "left"/"bottom" for backward compatibility and can be overridden when explicit control is needed.

## Test plan
- [ ] Verify existing code continues to work without specifying justify parameters
- [ ] Test label creation with explicit justify_h/justify_v values
- [ ] Verify labels render correctly in KiCad at different orientations

🤖 Generated with [Claude Code](https://claude.com/claude-code)