### PR TITLE
feat(labels): Add shape/rotation support and fix global label serialization

### DIFF
--- a/.claude/hooks/context_bundle_builder.py
+++ b/.claude/hooks/context_bundle_builder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run
+#!/usr/bin/env -S uv run
 # /// script
 # requires-python = ">=3.11"
 # dependencies = []

--- a/.claude/hooks/dangerous_command_blocker.py
+++ b/.claude/hooks/dangerous_command_blocker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run
+#!/usr/bin/env -S uv run
 # /// script
 # requires-python = ">=3.11"
 # dependencies = []

--- a/.claude/hooks/universal_hook_logger.py
+++ b/.claude/hooks/universal_hook_logger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run
+#!/usr/bin/env -S uv run
 # /// script
 # requires-python = ">=3.11"
 # dependencies = []

--- a/kicad_sch_api/collections/labels.py
+++ b/kicad_sch_api/collections/labels.py
@@ -253,6 +253,7 @@ class LabelCollection(BaseCollection[LabelElement]):
         justify_h: str = "left",
         justify_v: str = "bottom",
         uuid: Optional[str] = None,
+        shape: Optional[str] = None,
     ) -> LabelElement:
         """
         Add a label to the collection.
@@ -290,12 +291,14 @@ class LabelCollection(BaseCollection[LabelElement]):
             position = Point(position[0], position[1])
 
         # Create label data
+        from ..core.types import HierarchicalLabelShape
         label_data = Label(
             uuid=uuid,
             text=text.strip(),
             position=position,
             rotation=rotation,
             size=size,
+            shape=HierarchicalLabelShape(shape) if shape else None,
             justify_h=justify_h,
             justify_v=justify_v,
         )

--- a/kicad_sch_api/collections/labels.py
+++ b/kicad_sch_api/collections/labels.py
@@ -237,7 +237,7 @@ class LabelCollection(BaseCollection[LabelElement]):
         return [
             IndexSpec(
                 name="uuid",
-                key_func=lambda l: l.uuid,
+                key_func=lambda label: label.uuid,
                 unique=True,
                 description="UUID index for fast lookups",
             ),
@@ -292,6 +292,7 @@ class LabelCollection(BaseCollection[LabelElement]):
 
         # Create label data
         from ..core.types import HierarchicalLabelShape
+
         label_data = Label(
             uuid=uuid,
             text=text.strip(),
@@ -456,7 +457,7 @@ class LabelCollection(BaseCollection[LabelElement]):
             return base_stats
 
         unique_texts = len(self._text_index)
-        avg_size = sum(l.size for l in self._items) / len(self._items)
+        avg_size = sum(label.size for label in self._items) / len(self._items)
 
         base_stats = super().get_statistics()
         base_stats.update(

--- a/kicad_sch_api/core/managers/text_elements.py
+++ b/kicad_sch_api/core/managers/text_elements.py
@@ -96,6 +96,7 @@ class TextElementManager(BaseManager):
         text: str,
         position: Union[Point, Tuple[float, float]],
         shape: str = "input",
+        rotation: float = 0.0,
         effects: Optional[Dict[str, Any]] = None,
         uuid_str: Optional[str] = None,
     ) -> str:
@@ -106,6 +107,7 @@ class TextElementManager(BaseManager):
             text: Label text
             position: Label position
             shape: Shape type (input, output, bidirectional, tri_state, passive)
+            rotation: Label rotation in degrees (default 0)
             effects: Text effects
             uuid_str: Optional UUID
 
@@ -120,6 +122,8 @@ class TextElementManager(BaseManager):
 
         if effects is None:
             effects = self._get_default_text_effects()
+            justify = "right" if rotation in (180, 180.0, 270, 270.0) else "left"
+            effects["justify"] = [justify]
 
         valid_shapes = ["input", "output", "bidirectional", "tri_state", "passive"]
         if shape not in valid_shapes:
@@ -130,7 +134,7 @@ class TextElementManager(BaseManager):
             "uuid": uuid_str,
             "text": text,
             "shape": shape,
-            "at": [position.x, position.y, 0],
+            "at": [position.x, position.y, rotation],
             "effects": effects,
         }
 
@@ -147,6 +151,7 @@ class TextElementManager(BaseManager):
         text: str,
         position: Union[Point, Tuple[float, float]],
         shape: str = "input",
+        rotation: float = 0.0,
         effects: Optional[Dict[str, Any]] = None,
         uuid_str: Optional[str] = None,
     ) -> str:
@@ -157,6 +162,7 @@ class TextElementManager(BaseManager):
             text: Label text
             position: Label position
             shape: Shape type
+            rotation: Label rotation in degrees (default 0)
             effects: Text effects
             uuid_str: Optional UUID
 
@@ -171,6 +177,8 @@ class TextElementManager(BaseManager):
 
         if effects is None:
             effects = self._get_default_text_effects()
+            justify = "right" if rotation in (180, 180.0, 270, 270.0) else "left"
+            effects["justify"] = [justify]
 
         valid_shapes = ["input", "output", "bidirectional", "tri_state", "passive"]
         if shape not in valid_shapes:
@@ -181,7 +189,7 @@ class TextElementManager(BaseManager):
             "uuid": uuid_str,
             "text": text,
             "shape": shape,
-            "at": [position.x, position.y, 0],
+            "at": [position.x, position.y, rotation],
             "effects": effects,
         }
 

--- a/kicad_sch_api/core/parser.py
+++ b/kicad_sch_api/core/parser.py
@@ -219,6 +219,7 @@ class SExpressionParser:
             "junctions": [],
             "labels": [],
             "hierarchical_labels": [],
+            "global_label": [],
             "no_connects": [],
             "texts": [],
             "text_boxes": [],
@@ -278,6 +279,10 @@ class SExpressionParser:
                 hlabel = self._parse_hierarchical_label(item)
                 if hlabel:
                     schematic_data["hierarchical_labels"].append(hlabel)
+            elif element_type == "global_label":
+                glabel = self._parse_global_label(item)
+                if glabel:
+                    schematic_data["global_label"].append(glabel)
             elif element_type == "no_connect":
                 no_connect = self._parse_no_connect(item)
                 if no_connect:
@@ -378,6 +383,10 @@ class SExpressionParser:
         for hlabel in schematic_data.get("hierarchical_labels", []):
             sexp_data.append(self._hierarchical_label_to_sexp(hlabel))
 
+        # Add global labels
+        for glabel in schematic_data.get("global_label", []):
+            sexp_data.append(self._global_label_to_sexp(glabel))
+
         # Add no_connects
         for no_connect in schematic_data.get("no_connects", []):
             sexp_data.append(self._no_connect_to_sexp(no_connect))
@@ -468,6 +477,10 @@ class SExpressionParser:
     def _parse_hierarchical_label(self, item: List[Any]) -> Optional[Dict[str, Any]]:
         """Parse a hierarchical label definition."""
         return self._label_parser._parse_hierarchical_label(item)
+
+    def _parse_global_label(self, item: List[Any]) -> Optional[Dict[str, Any]]:
+        """Parse a global label definition."""
+        return self._label_parser._parse_global_label(item)
 
     def _parse_no_connect(self, item: List[Any]) -> Optional[Dict[str, Any]]:
         """Parse a no_connect symbol."""
@@ -621,6 +634,10 @@ class SExpressionParser:
     def _hierarchical_label_to_sexp(self, hlabel_data: Dict[str, Any]) -> List[Any]:
         """Convert hierarchical label to S-expression."""
         return self._label_parser._hierarchical_label_to_sexp(hlabel_data)
+
+    def _global_label_to_sexp(self, glabel_data: Dict[str, Any]) -> List[Any]:
+        """Convert global label to S-expression."""
+        return self._label_parser._global_label_to_sexp(glabel_data)
 
     def _no_connect_to_sexp(self, no_connect_data: Dict[str, Any]) -> List[Any]:
         """Convert no_connect to S-expression."""

--- a/kicad_sch_api/core/parser.py
+++ b/kicad_sch_api/core/parser.py
@@ -6,9 +6,8 @@ with exact format preservation and enhanced error handling.
 """
 
 import logging
-import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import sexpdata
 
@@ -23,7 +22,7 @@ from ..parsers.elements.wire_parser import WireParser
 from ..parsers.utils import color_to_rgb255, color_to_rgba
 from ..utils.validation import ValidationError, ValidationIssue
 from .formatter import ExactFormatter
-from .types import Junction, Label, Net, Point, SchematicSymbol, Wire
+from .types import Point
 
 logger = logging.getLogger(__name__)
 

--- a/kicad_sch_api/core/schematic.py
+++ b/kicad_sch_api/core/schematic.py
@@ -8,18 +8,14 @@ and maintainability.
 
 import logging
 import time
-import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
-
-import sexpdata
 
 from ..collections import (
     BusEntryCollection,
     ComponentCollection,
     JunctionCollection,
     LabelCollection,
-    LabelElement,
     WireCollection,
 )
 from ..library.cache import get_symbol_cache
@@ -42,22 +38,9 @@ from .no_connects import NoConnectCollection
 from .parser import SExpressionParser
 from .texts import TextCollection
 from .types import (
-    BusEntry,
-    HierarchicalLabelShape,
-    Junction,
-    Label,
     LabelType,
-    Net,
-    NoConnect,
     Point,
     SchematicSymbol,
-    Sheet,
-    Text,
-    TextBox,
-    TitleBlock,
-    Wire,
-    WireType,
-    point_from_dict_or_tuple,
 )
 
 logger = logging.getLogger(__name__)
@@ -1090,8 +1073,12 @@ class Schematic:
         # Use the hierarchical_labels collection
         justify_h = "right" if rotation in (180, 180.0, 270, 270.0) else "left"
         hlabel = self._hierarchical_labels.add(
-            text, position, rotation=rotation, size=size,
-            shape=shape, justify_h=justify_h,
+            text,
+            position,
+            rotation=rotation,
+            size=size,
+            shape=shape,
+            justify_h=justify_h,
         )
         self._sync_hierarchical_labels_to_data()  # Sync immediately
         self._format_sync_manager.mark_dirty("hierarchical_label", "add", {"uuid": hlabel.uuid})
@@ -1120,7 +1107,11 @@ class Schematic:
             UUID of created global label
         """
         label_uuid = self._text_element_manager.add_global_label(
-            text, position, shape, rotation=rotation, effects=effects,
+            text,
+            position,
+            shape,
+            rotation=rotation,
+            effects=effects,
         )
         self._format_sync_manager.mark_dirty("global_label", "add", {"uuid": label_uuid})
         self._modified = True
@@ -1888,7 +1879,6 @@ class Schematic:
             if isinstance(element, list) and len(element) >= 2:
                 # Check if this is a project element: ['project', 'old_name', ...]
                 if hasattr(element[0], "__str__") and str(element[0]) == "project":
-                    old_name = element[1]
                     element[1] = self.name  # Replace with current schematic name
                 else:
                     # Recursively check nested elements

--- a/kicad_sch_api/core/schematic.py
+++ b/kicad_sch_api/core/schematic.py
@@ -862,8 +862,12 @@ class Schematic:
             raise ValueError("Cannot provide both position and pin")
 
         # Handle pin-based placement
-        justify_h = "left"
         justify_v = "bottom"
+
+        if pin is None:
+            # Position-based: compute justify from rotation
+            effective_rotation = rotation if rotation is not None else 0
+            justify_h = "right" if effective_rotation in (180, 180.0, 270, 270.0) else "left"
 
         if pin is not None:
             component_ref, pin_number = pin
@@ -1084,7 +1088,11 @@ class Schematic:
             UUID of created hierarchical label
         """
         # Use the hierarchical_labels collection
-        hlabel = self._hierarchical_labels.add(text, position, rotation=rotation, size=size)
+        justify_h = "right" if rotation in (180, 180.0, 270, 270.0) else "left"
+        hlabel = self._hierarchical_labels.add(
+            text, position, rotation=rotation, size=size,
+            shape=shape, justify_h=justify_h,
+        )
         self._sync_hierarchical_labels_to_data()  # Sync immediately
         self._format_sync_manager.mark_dirty("hierarchical_label", "add", {"uuid": hlabel.uuid})
         self._modified = True
@@ -1095,6 +1103,7 @@ class Schematic:
         text: str,
         position: Union[Point, Tuple[float, float]],
         shape: str = "input",
+        rotation: float = 0.0,
         effects: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
@@ -1104,12 +1113,15 @@ class Schematic:
             text: Label text
             position: Label position
             shape: Shape type
+            rotation: Label rotation in degrees (default 0)
             effects: Text effects
 
         Returns:
             UUID of created global label
         """
-        label_uuid = self._text_element_manager.add_global_label(text, position, shape, effects)
+        label_uuid = self._text_element_manager.add_global_label(
+            text, position, shape, rotation=rotation, effects=effects,
+        )
         self._format_sync_manager.mark_dirty("global_label", "add", {"uuid": label_uuid})
         self._modified = True
         return label_uuid
@@ -1772,7 +1784,10 @@ class Schematic:
                 "position": {"x": hlabel_element.position.x, "y": hlabel_element.position.y},
                 "rotation": hlabel_element.rotation,
                 "size": hlabel_element.size,
+                "justify": hlabel_element._data.justify_h,
             }
+            if hlabel_element._data.shape is not None:
+                hlabel_dict["shape"] = hlabel_element._data.shape.value
             hierarchical_label_data.append(hlabel_dict)
 
         self._data["hierarchical_labels"] = hierarchical_label_data

--- a/kicad_sch_api/parsers/elements/label_parser.py
+++ b/kicad_sch_api/parsers/elements/label_parser.py
@@ -195,14 +195,20 @@ class LabelParser(BaseElementParser):
                             # Parse font properties
                             for font_elem in effect_elem[1:]:
                                 if isinstance(font_elem, list):
-                                    font_prop = str(font_elem[0]) if isinstance(font_elem[0], sexpdata.Symbol) else None
+                                    font_prop = (
+                                        str(font_elem[0])
+                                        if isinstance(font_elem[0], sexpdata.Symbol)
+                                        else None
+                                    )
                                     if font_prop == "size" and len(font_elem) >= 3:
                                         glabel_data["effects"]["font"]["size"] = [
                                             float(font_elem[1]),
                                             float(font_elem[2]),
                                         ]
                                     elif font_prop == "thickness" and len(font_elem) >= 2:
-                                        glabel_data["effects"]["font"]["thickness"] = float(font_elem[1])
+                                        glabel_data["effects"]["font"]["thickness"] = float(
+                                            font_elem[1]
+                                        )
 
                         elif effect_type == "justify":
                             # Parse justification: (justify left) or (justify right bottom)

--- a/kicad_sch_api/parsers/elements/label_parser.py
+++ b/kicad_sch_api/parsers/elements/label_parser.py
@@ -142,6 +142,80 @@ class LabelParser(BaseElementParser):
 
         return hlabel_data
 
+    def _parse_global_label(self, item: List[Any]) -> Optional[Dict[str, Any]]:
+        """Parse a global label definition."""
+        # Format: (global_label "text" (shape input) (at x y rotation) (effects (font ...) (justify ...)) (uuid ...))
+        if len(item) < 2:
+            return None
+
+        glabel_data = {
+            "text": str(item[1]),  # Global label text is second element
+            "shape": "input",
+            "at": [0, 0, 0],  # [x, y, rotation]
+            "effects": {
+                "font": {"size": [1.27, 1.27], "thickness": 0.254},
+                "justify": ["left"],
+            },
+            "uuid": None,
+        }
+
+        for elem in item[2:]:  # Skip global_label keyword and text
+            if not isinstance(elem, list):
+                continue
+
+            elem_type = str(elem[0]) if isinstance(elem[0], sexpdata.Symbol) else None
+
+            if elem_type == "shape":
+                # Parse shape: (shape input)
+                if len(elem) >= 2:
+                    glabel_data["shape"] = str(elem[1])
+
+            elif elem_type == "at":
+                # Parse position and rotation: (at x y rotation)
+                at_list = [0, 0, 0]
+                if len(elem) >= 2:
+                    at_list[0] = float(elem[1])
+                if len(elem) >= 3:
+                    at_list[1] = float(elem[2])
+                if len(elem) >= 4:
+                    at_list[2] = float(elem[3])
+                glabel_data["at"] = at_list
+
+            elif elem_type == "effects":
+                # Parse effects: (effects (font (size x y) (thickness t)) (justify left/right))
+                for effect_elem in elem[1:]:
+                    if isinstance(effect_elem, list):
+                        effect_type = (
+                            str(effect_elem[0])
+                            if isinstance(effect_elem[0], sexpdata.Symbol)
+                            else None
+                        )
+
+                        if effect_type == "font":
+                            # Parse font properties
+                            for font_elem in effect_elem[1:]:
+                                if isinstance(font_elem, list):
+                                    font_prop = str(font_elem[0]) if isinstance(font_elem[0], sexpdata.Symbol) else None
+                                    if font_prop == "size" and len(font_elem) >= 3:
+                                        glabel_data["effects"]["font"]["size"] = [
+                                            float(font_elem[1]),
+                                            float(font_elem[2]),
+                                        ]
+                                    elif font_prop == "thickness" and len(font_elem) >= 2:
+                                        glabel_data["effects"]["font"]["thickness"] = float(font_elem[1])
+
+                        elif effect_type == "justify":
+                            # Parse justification: (justify left) or (justify right bottom)
+                            justify_list = []
+                            for j in effect_elem[1:]:
+                                justify_list.append(str(j))
+                            glabel_data["effects"]["justify"] = justify_list
+
+            elif elem_type == "uuid":
+                glabel_data["uuid"] = str(elem[1]) if len(elem) > 1 else None
+
+        return glabel_data
+
     def _label_to_sexp(self, label_data: Dict[str, Any]) -> List[Any]:
         """Convert local label to S-expression."""
         sexp = [sexpdata.Symbol("label"), label_data["text"]]
@@ -207,5 +281,49 @@ class LabelParser(BaseElementParser):
         # Add UUID
         if "uuid" in hlabel_data:
             sexp.append([sexpdata.Symbol("uuid"), hlabel_data["uuid"]])
+
+        return sexp
+
+    def _global_label_to_sexp(self, glabel_data: Dict[str, Any]) -> List[Any]:
+        """Convert global label to S-expression."""
+        sexp = [sexpdata.Symbol("global_label"), glabel_data["text"]]
+
+        # Add shape
+        shape = glabel_data.get("shape", "input")
+        sexp.append([sexpdata.Symbol("shape"), sexpdata.Symbol(shape)])
+
+        # Add position with rotation
+        at_data = glabel_data.get("at", [0, 0, 0])
+        if isinstance(at_data, list) and len(at_data) >= 3:
+            x, y, rotation = at_data[0], at_data[1], at_data[2]
+        else:
+            x, y, rotation = at_data[0], at_data[1], 0 if len(at_data) >= 2 else (0, 0, 0)
+        sexp.append([sexpdata.Symbol("at"), x, y, rotation])
+
+        # Add effects (font and justify)
+        effects_data = glabel_data.get("effects", {})
+        effects = [sexpdata.Symbol("effects")]
+
+        # Font
+        font_data = effects_data.get("font", {})
+        font_size = font_data.get("size", [1.27, 1.27])
+        font = [sexpdata.Symbol("font"), [sexpdata.Symbol("size"), font_size[0], font_size[1]]]
+        if "thickness" in font_data:
+            font.append([sexpdata.Symbol("thickness"), font_data["thickness"]])
+        effects.append(font)
+
+        # Justify
+        justify_list = effects_data.get("justify", ["left"])
+        if justify_list:
+            justify = [sexpdata.Symbol("justify")]
+            for j in justify_list:
+                justify.append(sexpdata.Symbol(j) if isinstance(j, str) else j)
+            effects.append(justify)
+
+        sexp.append(effects)
+
+        # Add UUID
+        if "uuid" in glabel_data:
+            sexp.append([sexpdata.Symbol("uuid"), glabel_data["uuid"]])
 
         return sexp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "kicad-sch-api"
 version = "0.5.6"
 description = "Professional KiCAD schematic manipulation library with exact format preservation"
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT"}
 authors = [
     {name = "Circuit-Synth", email = "shane@circuit-synth.com"}
 ]

--- a/tests/unit/test_hlabel_shape_and_justify.py
+++ b/tests/unit/test_hlabel_shape_and_justify.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Tests for hierarchical label shape and justify functionality (Issue #204)."""
+
+import pytest
+import kicad_sch_api as ksa
+
+
+class TestHierarchicalLabelShape:
+    """Test shape parameter support for hierarchical labels."""
+
+    def test_hierarchical_label_with_input_shape(self):
+        """Test creating hierarchical label with input shape."""
+        sch = ksa.create_schematic("TestHLabelShape")
+        hlabel = sch.add_hierarchical_label(
+            "DATA_IN",
+            position=(100, 100),
+            shape="input",
+            rotation=0
+        )
+
+        # Verify shape is set
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["shape"] == "input"
+
+    def test_hierarchical_label_with_output_shape(self):
+        """Test creating hierarchical label with output shape."""
+        sch = ksa.create_schematic("TestHLabelShape")
+        sch.add_hierarchical_label(
+            "DATA_OUT",
+            position=(100, 100),
+            shape="output",
+            rotation=0
+        )
+
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["shape"] == "output"
+
+    def test_hierarchical_label_with_bidirectional_shape(self):
+        """Test creating hierarchical label with bidirectional shape."""
+        sch = ksa.create_schematic("TestHLabelShape")
+        sch.add_hierarchical_label(
+            "DATA_BUS",
+            position=(100, 100),
+            shape="bidirectional",
+            rotation=0
+        )
+
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["shape"] == "bidirectional"
+
+    def test_hierarchical_label_with_tri_state_shape(self):
+        """Test creating hierarchical label with tri_state shape."""
+        sch = ksa.create_schematic("TestHLabelShape")
+        sch.add_hierarchical_label(
+            "CONTROL",
+            position=(100, 100),
+            shape="tri_state",
+            rotation=0
+        )
+
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["shape"] == "tri_state"
+
+    def test_hierarchical_label_with_passive_shape(self):
+        """Test creating hierarchical label with passive shape."""
+        sch = ksa.create_schematic("TestHLabelShape")
+        sch.add_hierarchical_label(
+            "PASSIVE",
+            position=(100, 100),
+            shape="passive",
+            rotation=0
+        )
+
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["shape"] == "passive"
+
+    def test_hierarchical_label_shape_persists_after_save_load(self):
+        """Test that shape persists through save/load cycle."""
+        sch = ksa.create_schematic("TestHLabelShape")
+        sch.add_hierarchical_label(
+            "DATA",
+            position=(100, 100),
+            shape="bidirectional",
+            rotation=0
+        )
+
+        # Save and reload
+        sch.save("/tmp/test_hlabel_shape.kicad_sch")
+        sch2 = ksa.Schematic.load("/tmp/test_hlabel_shape.kicad_sch")
+
+        hlabel_data = sch2._data["hierarchical_labels"][0]
+        assert hlabel_data["shape"] == "bidirectional"
+
+
+class TestHierarchicalLabelJustify:
+    """Test automatic justify calculation for hierarchical labels."""
+
+    def test_hierarchical_label_justify_0deg(self):
+        """Test justify is 'left' for 0° rotation."""
+        sch = ksa.create_schematic("TestHLabelJustify")
+        sch.add_hierarchical_label(
+            "DATA",
+            position=(100, 100),
+            rotation=0,
+            shape="input"
+        )
+
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["justify"] == "left"
+
+    def test_hierarchical_label_justify_90deg(self):
+        """Test justify is 'left' for 90° rotation."""
+        sch = ksa.create_schematic("TestHLabelJustify")
+        sch.add_hierarchical_label(
+            "DATA",
+            position=(100, 100),
+            rotation=90,
+            shape="input"
+        )
+
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["justify"] == "left"
+
+    def test_hierarchical_label_justify_180deg(self):
+        """Test justify is 'right' for 180° rotation."""
+        sch = ksa.create_schematic("TestHLabelJustify")
+        sch.add_hierarchical_label(
+            "DATA",
+            position=(100, 100),
+            rotation=180,
+            shape="input"
+        )
+
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["justify"] == "right"
+
+    def test_hierarchical_label_justify_270deg(self):
+        """Test justify is 'right' for 270° rotation."""
+        sch = ksa.create_schematic("TestHLabelJustify")
+        sch.add_hierarchical_label(
+            "DATA",
+            position=(100, 100),
+            rotation=270,
+            shape="input"
+        )
+
+        hlabel_data = sch._data["hierarchical_labels"][0]
+        assert hlabel_data["justify"] == "right"
+
+
+class TestGlobalLabelRotation:
+    """Test rotation parameter support for global labels."""
+
+    def test_global_label_with_rotation_0(self):
+        """Test creating global label with 0° rotation."""
+        sch = ksa.create_schematic("TestGlobalLabel")
+        label_uuid = sch.add_global_label(
+            "VCC",
+            position=(100, 100),
+            shape="input",
+            rotation=0
+        )
+
+        # Find the global label in the data (stored as singular 'global_label')
+        global_label = None
+        for elem in sch._data.get("global_label", []):
+            if elem.get("uuid") == label_uuid:
+                global_label = elem
+                break
+
+        assert global_label is not None
+        assert global_label["at"][2] == 0  # rotation is third element of 'at'
+
+    def test_global_label_with_rotation_90(self):
+        """Test creating global label with 90° rotation."""
+        sch = ksa.create_schematic("TestGlobalLabel")
+        label_uuid = sch.add_global_label(
+            "VCC",
+            position=(100, 100),
+            shape="input",
+            rotation=90
+        )
+
+        global_label = None
+        for elem in sch._data.get("global_label", []):
+            if elem.get("uuid") == label_uuid:
+                global_label = elem
+                break
+
+        assert global_label is not None
+        assert global_label["at"][2] == 90
+
+    def test_global_label_with_rotation_180(self):
+        """Test creating global label with 180° rotation."""
+        sch = ksa.create_schematic("TestGlobalLabel")
+        label_uuid = sch.add_global_label(
+            "VCC",
+            position=(100, 100),
+            shape="input",
+            rotation=180
+        )
+
+        global_label = None
+        for elem in sch._data.get("global_label", []):
+            if elem.get("uuid") == label_uuid:
+                global_label = elem
+                break
+
+        assert global_label is not None
+        assert global_label["at"][2] == 180
+
+    def test_global_label_with_rotation_270(self):
+        """Test creating global label with 270° rotation."""
+        sch = ksa.create_schematic("TestGlobalLabel")
+        label_uuid = sch.add_global_label(
+            "VCC",
+            position=(100, 100),
+            shape="input",
+            rotation=270
+        )
+
+        global_label = None
+        for elem in sch._data.get("global_label", []):
+            if elem.get("uuid") == label_uuid:
+                global_label = elem
+                break
+
+        assert global_label is not None
+        assert global_label["at"][2] == 270
+
+    def test_global_label_rotation_persists_after_save_load(self):
+        """Test that rotation persists through save/load cycle."""
+        sch = ksa.create_schematic("TestGlobalLabel")
+        sch.add_global_label(
+            "GND",
+            position=(100, 100),
+            shape="input",
+            rotation=270
+        )
+
+        # Save and reload
+        sch.save("/tmp/test_global_label_rotation.kicad_sch")
+        sch2 = ksa.Schematic.load("/tmp/test_global_label_rotation.kicad_sch")
+
+        global_label = sch2._data.get("global_label", [])[0]
+        assert global_label["at"][2] == 270
+
+
+class TestGlobalLabelJustify:
+    """Test automatic justify calculation for global labels."""
+
+    def test_global_label_justify_0deg(self):
+        """Test justify is 'left' for 0° rotation."""
+        sch = ksa.create_schematic("TestGlobalLabelJustify")
+        label_uuid = sch.add_global_label(
+            "VCC",
+            position=(100, 100),
+            shape="input",
+            rotation=0
+        )
+
+        global_label = None
+        for elem in sch._data.get("global_label", []):
+            if elem.get("uuid") == label_uuid:
+                global_label = elem
+                break
+
+        effects = global_label.get("effects", {})
+        justify = effects.get("justify", [])
+        assert "left" in justify
+
+    def test_global_label_justify_180deg(self):
+        """Test justify is 'right' for 180° rotation."""
+        sch = ksa.create_schematic("TestGlobalLabelJustify")
+        label_uuid = sch.add_global_label(
+            "VCC",
+            position=(100, 100),
+            shape="input",
+            rotation=180
+        )
+
+        global_label = None
+        for elem in sch._data.get("global_label", []):
+            if elem.get("uuid") == label_uuid:
+                global_label = elem
+                break
+
+        effects = global_label.get("effects", {})
+        justify = effects.get("justify", [])
+        assert "right" in justify
+
+    def test_global_label_justify_270deg(self):
+        """Test justify is 'right' for 270° rotation."""
+        sch = ksa.create_schematic("TestGlobalLabelJustify")
+        label_uuid = sch.add_global_label(
+            "VCC",
+            position=(100, 100),
+            shape="input",
+            rotation=270
+        )
+
+        global_label = None
+        for elem in sch._data.get("global_label", []):
+            if elem.get("uuid") == label_uuid:
+                global_label = elem
+                break
+
+        effects = global_label.get("effects", {})
+        justify = effects.get("justify", [])
+        assert "right" in justify

--- a/tests/unit/test_hlabel_shape_and_justify.py
+++ b/tests/unit/test_hlabel_shape_and_justify.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for hierarchical label shape and justify functionality (Issue #204)."""
 
-import pytest
 import kicad_sch_api as ksa
 
 
@@ -11,12 +10,7 @@ class TestHierarchicalLabelShape:
     def test_hierarchical_label_with_input_shape(self):
         """Test creating hierarchical label with input shape."""
         sch = ksa.create_schematic("TestHLabelShape")
-        hlabel = sch.add_hierarchical_label(
-            "DATA_IN",
-            position=(100, 100),
-            shape="input",
-            rotation=0
-        )
+        sch.add_hierarchical_label("DATA_IN", position=(100, 100), shape="input", rotation=0)
 
         # Verify shape is set
         hlabel_data = sch._data["hierarchical_labels"][0]
@@ -25,12 +19,7 @@ class TestHierarchicalLabelShape:
     def test_hierarchical_label_with_output_shape(self):
         """Test creating hierarchical label with output shape."""
         sch = ksa.create_schematic("TestHLabelShape")
-        sch.add_hierarchical_label(
-            "DATA_OUT",
-            position=(100, 100),
-            shape="output",
-            rotation=0
-        )
+        sch.add_hierarchical_label("DATA_OUT", position=(100, 100), shape="output", rotation=0)
 
         hlabel_data = sch._data["hierarchical_labels"][0]
         assert hlabel_data["shape"] == "output"
@@ -39,10 +28,7 @@ class TestHierarchicalLabelShape:
         """Test creating hierarchical label with bidirectional shape."""
         sch = ksa.create_schematic("TestHLabelShape")
         sch.add_hierarchical_label(
-            "DATA_BUS",
-            position=(100, 100),
-            shape="bidirectional",
-            rotation=0
+            "DATA_BUS", position=(100, 100), shape="bidirectional", rotation=0
         )
 
         hlabel_data = sch._data["hierarchical_labels"][0]
@@ -51,12 +37,7 @@ class TestHierarchicalLabelShape:
     def test_hierarchical_label_with_tri_state_shape(self):
         """Test creating hierarchical label with tri_state shape."""
         sch = ksa.create_schematic("TestHLabelShape")
-        sch.add_hierarchical_label(
-            "CONTROL",
-            position=(100, 100),
-            shape="tri_state",
-            rotation=0
-        )
+        sch.add_hierarchical_label("CONTROL", position=(100, 100), shape="tri_state", rotation=0)
 
         hlabel_data = sch._data["hierarchical_labels"][0]
         assert hlabel_data["shape"] == "tri_state"
@@ -64,12 +45,7 @@ class TestHierarchicalLabelShape:
     def test_hierarchical_label_with_passive_shape(self):
         """Test creating hierarchical label with passive shape."""
         sch = ksa.create_schematic("TestHLabelShape")
-        sch.add_hierarchical_label(
-            "PASSIVE",
-            position=(100, 100),
-            shape="passive",
-            rotation=0
-        )
+        sch.add_hierarchical_label("PASSIVE", position=(100, 100), shape="passive", rotation=0)
 
         hlabel_data = sch._data["hierarchical_labels"][0]
         assert hlabel_data["shape"] == "passive"
@@ -77,12 +53,7 @@ class TestHierarchicalLabelShape:
     def test_hierarchical_label_shape_persists_after_save_load(self):
         """Test that shape persists through save/load cycle."""
         sch = ksa.create_schematic("TestHLabelShape")
-        sch.add_hierarchical_label(
-            "DATA",
-            position=(100, 100),
-            shape="bidirectional",
-            rotation=0
-        )
+        sch.add_hierarchical_label("DATA", position=(100, 100), shape="bidirectional", rotation=0)
 
         # Save and reload
         sch.save("/tmp/test_hlabel_shape.kicad_sch")
@@ -98,12 +69,7 @@ class TestHierarchicalLabelJustify:
     def test_hierarchical_label_justify_0deg(self):
         """Test justify is 'left' for 0° rotation."""
         sch = ksa.create_schematic("TestHLabelJustify")
-        sch.add_hierarchical_label(
-            "DATA",
-            position=(100, 100),
-            rotation=0,
-            shape="input"
-        )
+        sch.add_hierarchical_label("DATA", position=(100, 100), rotation=0, shape="input")
 
         hlabel_data = sch._data["hierarchical_labels"][0]
         assert hlabel_data["justify"] == "left"
@@ -111,12 +77,7 @@ class TestHierarchicalLabelJustify:
     def test_hierarchical_label_justify_90deg(self):
         """Test justify is 'left' for 90° rotation."""
         sch = ksa.create_schematic("TestHLabelJustify")
-        sch.add_hierarchical_label(
-            "DATA",
-            position=(100, 100),
-            rotation=90,
-            shape="input"
-        )
+        sch.add_hierarchical_label("DATA", position=(100, 100), rotation=90, shape="input")
 
         hlabel_data = sch._data["hierarchical_labels"][0]
         assert hlabel_data["justify"] == "left"
@@ -124,12 +85,7 @@ class TestHierarchicalLabelJustify:
     def test_hierarchical_label_justify_180deg(self):
         """Test justify is 'right' for 180° rotation."""
         sch = ksa.create_schematic("TestHLabelJustify")
-        sch.add_hierarchical_label(
-            "DATA",
-            position=(100, 100),
-            rotation=180,
-            shape="input"
-        )
+        sch.add_hierarchical_label("DATA", position=(100, 100), rotation=180, shape="input")
 
         hlabel_data = sch._data["hierarchical_labels"][0]
         assert hlabel_data["justify"] == "right"
@@ -137,12 +93,7 @@ class TestHierarchicalLabelJustify:
     def test_hierarchical_label_justify_270deg(self):
         """Test justify is 'right' for 270° rotation."""
         sch = ksa.create_schematic("TestHLabelJustify")
-        sch.add_hierarchical_label(
-            "DATA",
-            position=(100, 100),
-            rotation=270,
-            shape="input"
-        )
+        sch.add_hierarchical_label("DATA", position=(100, 100), rotation=270, shape="input")
 
         hlabel_data = sch._data["hierarchical_labels"][0]
         assert hlabel_data["justify"] == "right"
@@ -154,12 +105,7 @@ class TestGlobalLabelRotation:
     def test_global_label_with_rotation_0(self):
         """Test creating global label with 0° rotation."""
         sch = ksa.create_schematic("TestGlobalLabel")
-        label_uuid = sch.add_global_label(
-            "VCC",
-            position=(100, 100),
-            shape="input",
-            rotation=0
-        )
+        label_uuid = sch.add_global_label("VCC", position=(100, 100), shape="input", rotation=0)
 
         # Find the global label in the data (stored as singular 'global_label')
         global_label = None
@@ -174,12 +120,7 @@ class TestGlobalLabelRotation:
     def test_global_label_with_rotation_90(self):
         """Test creating global label with 90° rotation."""
         sch = ksa.create_schematic("TestGlobalLabel")
-        label_uuid = sch.add_global_label(
-            "VCC",
-            position=(100, 100),
-            shape="input",
-            rotation=90
-        )
+        label_uuid = sch.add_global_label("VCC", position=(100, 100), shape="input", rotation=90)
 
         global_label = None
         for elem in sch._data.get("global_label", []):
@@ -193,12 +134,7 @@ class TestGlobalLabelRotation:
     def test_global_label_with_rotation_180(self):
         """Test creating global label with 180° rotation."""
         sch = ksa.create_schematic("TestGlobalLabel")
-        label_uuid = sch.add_global_label(
-            "VCC",
-            position=(100, 100),
-            shape="input",
-            rotation=180
-        )
+        label_uuid = sch.add_global_label("VCC", position=(100, 100), shape="input", rotation=180)
 
         global_label = None
         for elem in sch._data.get("global_label", []):
@@ -212,12 +148,7 @@ class TestGlobalLabelRotation:
     def test_global_label_with_rotation_270(self):
         """Test creating global label with 270° rotation."""
         sch = ksa.create_schematic("TestGlobalLabel")
-        label_uuid = sch.add_global_label(
-            "VCC",
-            position=(100, 100),
-            shape="input",
-            rotation=270
-        )
+        label_uuid = sch.add_global_label("VCC", position=(100, 100), shape="input", rotation=270)
 
         global_label = None
         for elem in sch._data.get("global_label", []):
@@ -231,12 +162,7 @@ class TestGlobalLabelRotation:
     def test_global_label_rotation_persists_after_save_load(self):
         """Test that rotation persists through save/load cycle."""
         sch = ksa.create_schematic("TestGlobalLabel")
-        sch.add_global_label(
-            "GND",
-            position=(100, 100),
-            shape="input",
-            rotation=270
-        )
+        sch.add_global_label("GND", position=(100, 100), shape="input", rotation=270)
 
         # Save and reload
         sch.save("/tmp/test_global_label_rotation.kicad_sch")
@@ -252,12 +178,7 @@ class TestGlobalLabelJustify:
     def test_global_label_justify_0deg(self):
         """Test justify is 'left' for 0° rotation."""
         sch = ksa.create_schematic("TestGlobalLabelJustify")
-        label_uuid = sch.add_global_label(
-            "VCC",
-            position=(100, 100),
-            shape="input",
-            rotation=0
-        )
+        label_uuid = sch.add_global_label("VCC", position=(100, 100), shape="input", rotation=0)
 
         global_label = None
         for elem in sch._data.get("global_label", []):
@@ -272,12 +193,7 @@ class TestGlobalLabelJustify:
     def test_global_label_justify_180deg(self):
         """Test justify is 'right' for 180° rotation."""
         sch = ksa.create_schematic("TestGlobalLabelJustify")
-        label_uuid = sch.add_global_label(
-            "VCC",
-            position=(100, 100),
-            shape="input",
-            rotation=180
-        )
+        label_uuid = sch.add_global_label("VCC", position=(100, 100), shape="input", rotation=180)
 
         global_label = None
         for elem in sch._data.get("global_label", []):
@@ -292,12 +208,7 @@ class TestGlobalLabelJustify:
     def test_global_label_justify_270deg(self):
         """Test justify is 'right' for 270° rotation."""
         sch = ksa.create_schematic("TestGlobalLabelJustify")
-        label_uuid = sch.add_global_label(
-            "VCC",
-            position=(100, 100),
-            shape="input",
-            rotation=270
-        )
+        label_uuid = sch.add_global_label("VCC", position=(100, 100), shape="input", rotation=270)
 
         global_label = None
         for elem in sch._data.get("global_label", []):


### PR DESCRIPTION
## Summary

Adds missing shape and rotation support for hierarchical/global labels with automatic justify calculation, and fixes global label serialization bug.

## Changes

### Hierarchical Labels
- ✅ Add `shape` parameter to `add_hierarchical_label()` and `LabelCollection.add()`
- ✅ Add automatic justify calculation based on rotation (right for 180/270°, left otherwise)
- ✅ Sync shape and justify properties to hierarchical_labels data

### Global Labels (Fixes #204)
- ✅ Add `rotation` parameter to `add_global_label()`
- ✅ Add automatic justify calculation based on rotation
- ✅ Fix global label serialization:
  - Add `_global_label_to_sexp()` to convert global labels to S-expression
  - Add `_parse_global_label()` to parse global labels from files
  - Add global_label iteration loop in `_schematic_data_to_sexp()`
  - Initialize global_label list in schematic data structure

### Regular Labels
- ✅ Fix justify calculation in `add_label()` for position-based placement (was inverted)

## Testing

- ✅ Added 18 comprehensive tests covering shape, rotation, and justify functionality
- ✅ All label tests pass (hierarchical, global, and regular)
- ✅ Save/load roundtrip tests verify persistence
- ✅ All existing label tests still pass (no regressions)

## Example Usage

### Hierarchical Labels with Shape
```python
sch.add_hierarchical_label(
    "DATA_BUS",
    position=(100, 100),
    shape="bidirectional",  # New parameter
    rotation=0
)
```

### Global Labels with Rotation
```python
sch.add_global_label(
    "VCC",
    position=(150, 100),
    shape="input",
    rotation=270  # New parameter - now actually saved to file!
)
```

## Fixes

Closes #204

## Backward Compatibility

✅ Fully backward compatible - all new parameters are optional with sensible defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)